### PR TITLE
Handle errors properly in openebs-provisioner

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -36,7 +36,12 @@ import (
 )
 
 const (
+	//provisionerName defines name of the provisioner
 	provisionerName = "openebs.io/provisioner-iscsi"
+
+	//defaultProvisionerRetryCount is the number of times openebs provisioner
+	//will try to connect with maya-apiserver
+	defaultProvisionerRetryCount = 30
 )
 
 type openEBSProvisioner struct {
@@ -57,7 +62,7 @@ func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 	var openebsObj mApiv1.OpenEBSVolume
 
 	//Get maya-apiserver IP address from cluster
-	addr, err := openebsObj.GetMayaClusterIP(client)
+	addr, err := openebsObj.GetMayaClusterIP(client, defaultProvisionerRetryCount, 0)
 
 	if err != nil {
 		glog.Errorf("Error getting maya-api-server IP Address: %v", err)

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-
 	"syscall"
 
 	"github.com/golang/glog"
@@ -53,7 +52,7 @@ type openEBSProvisioner struct {
 func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		glog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
+		glog.Errorf("env variable NODE_NAME must be set so that this provisioner can identify itself")
 	}
 	var openebsObj mApiv1.OpenEBSVolume
 
@@ -61,9 +60,10 @@ func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 	addr, err := openebsObj.GetMayaClusterIP(client)
 
 	if err != nil {
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return nil
 	}
+
 	mayaServiceURI := "http://" + addr + ":5656"
 
 	//Set maya-apiserver IP address along with default port
@@ -88,13 +88,13 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	_, err := openebsVol.CreateVsm(options.PVName, volSize.String())
 	if err != nil {
-		glog.Fatalf("Error creating volume: %v", err)
+		glog.Errorf("Error creating volume: %v", err)
 		return nil, err
 	}
 
 	err = openebsVol.ListVsm(options.PVName, &volume)
 	if err != nil {
-		glog.Fatalf("Error getting volume details: %v", err)
+		glog.Errorf("Error getting volume details: %v", err)
 		return nil, err
 	}
 
@@ -184,18 +184,18 @@ func main() {
 	// to use to communicate with Kubernetes
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		glog.Fatalf("Failed to create config: %v", err)
+		glog.Errorf("Failed to create config: %v", err)
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		glog.Fatalf("Failed to create client: %v", err)
+		glog.Errorf("Failed to create client: %v", err)
 	}
 
 	// The controller needs to know what the server version is because out-of-tree
 	// provisioners aren't officially supported until 1.5
 	serverVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
-		glog.Fatalf("Error getting server version: %v", err)
+		glog.Errorf("Error getting server version: %v", err)
 	}
 
 	// Create the provisioner: it implements the Provisioner interface expected by

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	timeout = 60 * time.Second
+	timeout = 5 * time.Second
 )
 
 //OpenEBSVolumeInterface Interface to bind methods
@@ -55,15 +55,40 @@ type OpenEBSVolume struct{}
 func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, error) {
 	clusterIP := "127.0.0.1"
 
+	glog.Info("Checking maya-apiserver status")
+
 	//Fetch the Maya ClusterIP using the Maya API Server Service
 	sc, err := client.CoreV1().Services("default").Get("maya-apiserver-service", metav1.GetOptions{})
 	if err != nil {
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-apiserver IP Address: %v", err)
 	}
 
 	clusterIP = sc.Spec.ClusterIP
-	glog.Infof("Maya Cluster IP: %v", clusterIP)
+	glog.Infof("maya-apiserver Cluster IP: %v", clusterIP)
 
+	var url bytes.Buffer
+
+	addr := clusterIP
+
+	url.WriteString("http://" + addr + ":5656" + "/latest/meta-data/instance-id")
+	resp, err := http.Get(url.String())
+
+	if err != nil {
+		glog.Errorf("Error while connecting maya-apiserver %s", err)
+		time.Sleep(5 * time.Second)
+		return v.GetMayaClusterIP(client)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		glog.Errorf("maya-apiserver is not available: Error %s , HTTP Status Code: %d", err, resp.StatusCode)
+		time.Sleep(5 * time.Second)
+		return v.GetMayaClusterIP(client)
+	}
+
+	glog.V(2).Infof("maya-apiserver is available: Message %s , HTTP Status Code: %d", string(body), http.StatusText(resp.StatusCode))
 	return clusterIP, err
 }
 
@@ -75,7 +100,7 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return "Error getting maya-api-server IP Address", err
 	}
 	url := addr + "/latest/volumes/"
@@ -99,20 +124,20 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Fatalf("http.Do() error: : %v", err)
+		glog.Errorf("Could not connect to maya-api-server %v", err)
 		return "Could not connect to maya-api-server", err
 	}
 	defer resp.Body.Close()
 
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		glog.Fatalf("ioutil.ReadAll() error: : %v", err)
+		glog.Errorf("Unable to read response from maya-api-server %v", err)
 		return "Unable to read response from maya-api-server", err
 	}
 
-	code := resp.StatusCode
-	if code != http.StatusOK {
-		glog.Fatalf("Status error: %v\n", http.StatusText(code))
+	statusCode := resp.StatusCode
+	if statusCode != http.StatusOK {
+		glog.Errorf("HTTP Status error from maya-api-server: %v\n", http.StatusText(statusCode))
 		return "HTTP Status error from maya-api-server", err
 	}
 
@@ -126,7 +151,7 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return err
 	}
 	url := addr + "/latest/volumes/info/" + vname
@@ -172,14 +197,14 @@ func (v OpenEBSVolume) DeleteVsm(vname string) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Fatalf("http.Do() error: : %v", err)
+		glog.Errorf("http.Do() error: : %v", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		glog.Fatalf("Status error: %v\n", http.StatusText(code))
+		glog.Errorf("Status error: %v\n", http.StatusText(code))
 		return err
 	}
 	glog.Info("VSM Deleted Successfully initiated")


### PR DESCRIPTION
Key Changes:
* Perform check on the maya-apiserver while creating new
instance of OpenEBS Provisioner.

* Replacing `glog.Fatalf()` in favor of `glog.Errorf()` since,
`glog.Fatalf()` will exit with status 255 i.e `os.Exit(255)` and that will exit
the provisioner which will eventually make status of Provisioner
as 'Error'.

* Reduced the timeout for `maya-apiserver` request to 5 seconds
from 60 seconds.

For more info refer : https://github.com/openebs/openebs/issues/245 & https://github.com/openebs/openebs/issues/364
