### PR TITLE
Allow openebs-provisioner to pass storage class

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -85,8 +85,9 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	var openebsVol mApiv1.OpenEBSVolume
 
 	volSize := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	storageClassName := *options.PVC.Spec.StorageClassName
 
-	_, err := openebsVol.CreateVsm(options.PVName, volSize.String())
+	_, err := openebsVol.CreateVsm(options.PVName, volSize.String(), storageClassName)
 	if err != nil {
 		glog.Fatalf("Error creating volume: %v", err)
 		return nil, err

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -68,7 +68,7 @@ func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, er
 }
 
 // CreateVsm to create the Vsm through a API call to m-apiserver
-func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
+func (v OpenEBSVolume) CreateVsm(vname, size, storageClassName string) (string, error) {
 
 	var vs mayav1.VsmSpec
 
@@ -84,6 +84,7 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	vs.APIVersion = "v1"
 	vs.Metadata.Name = vname
 	vs.Metadata.Labels.Storage = size
+	vs.Metadata.Labels.StorageClass = storageClassName
 
 	//Marshal serializes the value provided into a YAML document
 	yamlValue, _ := yaml.Marshal(vs)

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -23,7 +23,8 @@ type VsmSpec struct {
 	Metadata   struct {
 		Name   string `yaml:"name"`
 		Labels struct {
-			Storage string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
+			Storage      string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
+			StorageClass string `yaml:"k8s.io/storage-class"`
 		}
 	} `yaml:"metadata"`
 }


### PR DESCRIPTION
`openebs-provisioner` has access to the PVC request and `openebs-provisioner` can pass `StorageClass`  to `maya-apiserver`. This PR does that.

Fixes: https://github.com/openebs/openebs/issues/691