### PR TITLE
Error handling openebs provisioner 

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -53,7 +53,7 @@ type openEBSProvisioner struct {
 func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		glog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
+		glog.Errorf("env variable NODE_NAME must be set so that this provisioner can identify itself")
 	}
 	var openebsObj mApiv1.OpenEBSVolume
 
@@ -61,7 +61,7 @@ func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 	addr, err := openebsObj.GetMayaClusterIP(client)
 
 	if err != nil {
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return nil
 	}
 	mayaServiceURI := "http://" + addr + ":5656"
@@ -85,16 +85,15 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	var openebsVol mApiv1.OpenEBSVolume
 
 	volSize := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-
 	_, err := openebsVol.CreateVsm(options.PVName, volSize.String())
 	if err != nil {
-		glog.Fatalf("Error creating volume: %v", err)
+		glog.Errorf("Error creating volume: %v", err)
 		return nil, err
 	}
 
 	err = openebsVol.ListVsm(options.PVName, &volume)
 	if err != nil {
-		glog.Fatalf("Error getting volume details: %v", err)
+		glog.Errorf("Error getting volume details: %v", err)
 		return nil, err
 	}
 
@@ -184,18 +183,18 @@ func main() {
 	// to use to communicate with Kubernetes
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		glog.Fatalf("Failed to create config: %v", err)
+		glog.Errorf("Failed to create config: %v", err)
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		glog.Fatalf("Failed to create client: %v", err)
+		glog.Errorf("Failed to create client: %v", err)
 	}
 
 	// The controller needs to know what the server version is because out-of-tree
 	// provisioners aren't officially supported until 1.5
 	serverVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
-		glog.Fatalf("Error getting server version: %v", err)
+		glog.Errorf("Error getting server version: %v", err)
 	}
 
 	// Create the provisioner: it implements the Provisioner interface expected by

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -61,7 +61,7 @@ func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 	addr, err := openebsObj.GetMayaClusterIP(client)
 
 	if err != nil {
-		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-apiserver IP Address: %v", err)
 		return nil
 	}
 	mayaServiceURI := "http://" + addr + ":5656"

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -58,7 +58,7 @@ func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, er
 	//Fetch the Maya ClusterIP using the Maya API Server Service
 	sc, err := client.CoreV1().Services("default").Get("maya-apiserver-service", metav1.GetOptions{})
 	if err != nil {
-		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-apiserver IP Address: %v", err)
 	}
 
 	clusterIP = sc.Spec.ClusterIP
@@ -75,8 +75,8 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
-		return "Error getting maya-api-server IP Address", err
+		glog.Errorf("Error getting maya-apiserver IP Address: %v", err)
+		return "Error getting maya-apiserver IP Address", err
 	}
 	url := addr + "/latest/volumes/"
 
@@ -99,21 +99,21 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Errorf("http.Do() error: : %v", err)
-		return "Could not connect to maya-api-server", err
+		glog.Errorf("Error when connecting maya-apiserver %v", err)
+		return "Could not connect to maya-apiserver", err
 	}
 	defer resp.Body.Close()
 
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		glog.Errorf("ioutil.ReadAll() error: : %v", err)
-		return "Unable to read response from maya-api-server", err
+		glog.Errorf("Unable to read response from maya-apiserver %v", err)
+		return "Unable to read response from maya-apiserver", err
 	}
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
 		glog.Errorf("Status error: %v\n", http.StatusText(code))
-		return "HTTP Status error from maya-api-server", err
+		return "HTTP Status error from maya-apiserver", err
 	}
 
 	glog.Infof("VSM Successfully Created:\n%v\n", string(data))
@@ -126,7 +126,7 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting mayaapi-server IP Address: %v", err)
 		return err
 	}
 	url := addr + "/latest/volumes/info/" + vname
@@ -139,14 +139,14 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Errorf("http.Do() error: : %v", err)
+		glog.Errorf("Error when connecting to maya-apiserver %v", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		glog.Errorf("Status error: %v\n", http.StatusText(code))
+		glog.Errorf("HTTP Status error from maya-apiserver: %v\n", http.StatusText(code))
 		return err
 	}
 	glog.Info("VSM Details Successfully Retrieved")
@@ -172,14 +172,14 @@ func (v OpenEBSVolume) DeleteVsm(vname string) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Errorf("http.Do() error: : %v", err)
+		glog.Errorf("Error when connecting to maya-apiserver  %v", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		glog.Errorf("Status error: %v\n", http.StatusText(code))
+		glog.Errorf("HTTP Status error from maya-apiserver: %v\n", http.StatusText(code))
 		return err
 	}
 	glog.Info("VSM Deleted Successfully initiated")

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -58,7 +58,7 @@ func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, er
 	//Fetch the Maya ClusterIP using the Maya API Server Service
 	sc, err := client.CoreV1().Services("default").Get("maya-apiserver-service", metav1.GetOptions{})
 	if err != nil {
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 	}
 
 	clusterIP = sc.Spec.ClusterIP
@@ -75,7 +75,7 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return "Error getting maya-api-server IP Address", err
 	}
 	url := addr + "/latest/volumes/"
@@ -99,20 +99,20 @@ func (v OpenEBSVolume) CreateVsm(vname string, size string) (string, error) {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Fatalf("http.Do() error: : %v", err)
+		glog.Errorf("http.Do() error: : %v", err)
 		return "Could not connect to maya-api-server", err
 	}
 	defer resp.Body.Close()
 
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		glog.Fatalf("ioutil.ReadAll() error: : %v", err)
+		glog.Errorf("ioutil.ReadAll() error: : %v", err)
 		return "Unable to read response from maya-api-server", err
 	}
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		glog.Fatalf("Status error: %v\n", http.StatusText(code))
+		glog.Errorf("Status error: %v\n", http.StatusText(code))
 		return "HTTP Status error from maya-api-server", err
 	}
 
@@ -126,7 +126,7 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return err
 	}
 	url := addr + "/latest/volumes/info/" + vname
@@ -139,14 +139,14 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Fatalf("http.Do() error: : %v", err)
+		glog.Errorf("http.Do() error: : %v", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		glog.Fatalf("Status error: %v\n", http.StatusText(code))
+		glog.Errorf("Status error: %v\n", http.StatusText(code))
 		return err
 	}
 	glog.Info("VSM Details Successfully Retrieved")
@@ -159,7 +159,7 @@ func (v OpenEBSVolume) DeleteVsm(vname string) error {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := errors.New("MAPI_ADDR environment variable not set")
-		glog.Fatalf("Error getting maya-api-server IP Address: %v", err)
+		glog.Errorf("Error getting maya-api-server IP Address: %v", err)
 		return err
 	}
 	url := addr + "/latest/volumes/delete/" + vname
@@ -172,14 +172,14 @@ func (v OpenEBSVolume) DeleteVsm(vname string) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Fatalf("http.Do() error: : %v", err)
+		glog.Errorf("http.Do() error: : %v", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		glog.Fatalf("Status error: %v\n", http.StatusText(code))
+		glog.Errorf("Status error: %v\n", http.StatusText(code))
 		return err
 	}
 	glog.Info("VSM Deleted Successfully initiated")


### PR DESCRIPTION
 Handle the errors in the openebs-provisioner properly. Here we are replacing `glog.Fatalf()` in the favor of
    `glog.Errorf()` and changing error messages to appropriate one.

Fixes: https://github.com/openebs/openebs/issues/245