### PR TITLE
Enhancements to the openebs-provisioner

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -54,7 +54,7 @@ func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
 
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		glog.Errorf("env variable NODE_NAME must be set so that this provisioner can identify itself")
+		glog.Errorf("ENV variable 'NODE_NAME' is not set")
 	}
 	var openebsObj mApiv1.OpenEBSVolume
 

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -51,6 +51,7 @@ type openEBSProvisioner struct {
 
 // NewOpenEBSProvisioner creates a new openebs provisioner
 func NewOpenEBSProvisioner(client kubernetes.Interface) controller.Provisioner {
+
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
 		glog.Errorf("env variable NODE_NAME must be set so that this provisioner can identify itself")
@@ -83,18 +84,22 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	//Issue a request to Maya API Server to create a volume
 	var volume mayav1.Volume
 	var openebsVol mApiv1.OpenEBSVolume
+	volumeSpec := mayav1.VolumeSpec{}
 
 	volSize := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-  
-	storageClassName := *options.PVC.Spec.StorageClassName
+	volumeSpec.Metadata.Labels.Storage = volSize.String()
 
-	_, err := openebsVol.CreateVsm(options.PVName, volSize.String(), storageClassName)
+	volumeSpec.Metadata.Labels.StorageClass = *options.PVC.Spec.StorageClassName
+	volumeSpec.Metadata.Labels.Namespace = options.PVC.Namespace
+	volumeSpec.Metadata.Name = options.PVName
+
+	_, err := openebsVol.CreateVolume(volumeSpec)
 	if err != nil {
 		glog.Errorf("Error creating volume: %v", err)
 		return nil, err
 	}
 
-	err = openebsVol.ListVsm(options.PVName, &volume)
+	err = openebsVol.ListVolume(options.PVName, &volume)
 	if err != nil {
 		glog.Errorf("Error getting volume details: %v", err)
 		return nil, err
@@ -161,7 +166,7 @@ func (p *openEBSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	}
 
 	// Issue a delete request to Maya API Server
-	err := openebsVol.DeleteVsm(volume.Name)
+	err := openebsVol.DeleteVolume(volume.Name)
 	if err != nil {
 		glog.Errorf("Error while deleting volume: %v", err)
 		return err

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -38,9 +38,9 @@ const (
 
 //OpenEBSVolumeInterface Interface to bind methods
 type OpenEBSVolumeInterface interface {
-	CreateVsm(string, string) (string, error)
-	ListVsm(string, interface{}) error
-	DeleteVsm(string) error
+	CreateVolume(mayav1.VolumeSpec) (string, error)
+	ListVolume(string, interface{}) error
+	DeleteVolume(string) error
 }
 
 //MayaInterface interface to hold maya specific methods
@@ -68,9 +68,7 @@ func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, er
 }
 
 // CreateVsm to create the Vsm through a API call to m-apiserver
-func (v OpenEBSVolume) CreateVsm(vname, size, storageClassName string) (string, error) {
-
-	var vs mayav1.VsmSpec
+func (v OpenEBSVolume) CreateVolume(vs mayav1.VolumeSpec) (string, error) {
 
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
@@ -82,14 +80,11 @@ func (v OpenEBSVolume) CreateVsm(vname, size, storageClassName string) (string, 
 
 	vs.Kind = "PersistentVolumeClaim"
 	vs.APIVersion = "v1"
-	vs.Metadata.Name = vname
-	vs.Metadata.Labels.Storage = size
-	vs.Metadata.Labels.StorageClass = storageClassName
 
 	//Marshal serializes the value provided into a YAML document
 	yamlValue, _ := yaml.Marshal(vs)
 
-	glog.Infof("VSM Spec Created:\n%v\n", string(yamlValue))
+	glog.Infof("Volume Spec Created:\n%v\n", string(yamlValue))
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
 
@@ -117,12 +112,12 @@ func (v OpenEBSVolume) CreateVsm(vname, size, storageClassName string) (string, 
 		return "HTTP Status error from maya-apiserver", err
 	}
 
-	glog.Infof("VSM Successfully Created:\n%v\n", string(data))
-	return "VSM Successfully Created", nil
+	glog.Infof("Volume Successfully Created:\n%v\n", string(data))
+	return "Volume Successfully Created", nil
 }
 
 // ListVsm to get the info of Vsm through a API call to m-apiserver
-func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
+func (v OpenEBSVolume) ListVolume(vname string, obj interface{}) error {
 
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
@@ -132,7 +127,7 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 	}
 	url := addr + "/latest/volumes/info/" + vname
 
-	glog.Infof("Get details for VSM :%v", string(vname))
+	glog.Infof("Get details for Volume :%v", string(vname))
 
 	req, err := http.NewRequest("GET", url, nil)
 	c := &http.Client{
@@ -150,12 +145,12 @@ func (v OpenEBSVolume) ListVsm(vname string, obj interface{}) error {
 		glog.Errorf("HTTP Status error from maya-apiserver: %v\n", http.StatusText(code))
 		return err
 	}
-	glog.Info("VSM Details Successfully Retrieved")
+	glog.Info("Volume Details Successfully Retrieved")
 	return json.NewDecoder(resp.Body).Decode(obj)
 }
 
 // DeleteVsm to get delete Vsm through a API call to m-apiserver
-func (v OpenEBSVolume) DeleteVsm(vname string) error {
+func (v OpenEBSVolume) DeleteVolume(vname string) error {
 
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
@@ -165,7 +160,7 @@ func (v OpenEBSVolume) DeleteVsm(vname string) error {
 	}
 	url := addr + "/latest/volumes/delete/" + vname
 
-	glog.Infof("Delete VSM :%v", string(vname))
+	glog.Infof("Delete Volume :%v", string(vname))
 
 	req, err := http.NewRequest("GET", url, nil)
 	c := &http.Client{
@@ -183,6 +178,6 @@ func (v OpenEBSVolume) DeleteVsm(vname string) error {
 		glog.Errorf("HTTP Status error from maya-apiserver: %v\n", http.StatusText(code))
 		return err
 	}
-	glog.Info("VSM Deleted Successfully initiated")
+	glog.Info("Volume Deleted Successfully initiated")
 	return nil
 }

--- a/openebs/pkg/v1/maya_api_test.go
+++ b/openebs/pkg/v1/maya_api_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	mayav1 "github.com/kubernetes-incubator/external-storage/openebs/types/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -42,21 +43,21 @@ func (mIP MayaClusterIPTest) GetMayaClusterIP(client kubernetes.Interface) (stri
 	return mIP.ClusterIP, nil
 }
 
-func (ov OpenEBSVolumeTest) CreateVsm(vaname string, size string) (string, error) {
+func (ov OpenEBSVolumeTest) CreateVolume(mayav1.VolumeSpec) (string, error) {
 	if ov.Err != nil {
 		return ov.Message, ov.Err
 	}
 	return ov.Message, nil
 }
 
-func (ov OpenEBSVolumeTest) ListVsm(vaname string, size interface{}) error {
+func (ov OpenEBSVolumeTest) ListVolume(vaname string, size interface{}) error {
 	if ov.Err != nil {
 		return ov.Err
 	}
 	return nil
 }
 
-func (ov OpenEBSVolumeTest) DeleteVsm(vname string) error {
+func (ov OpenEBSVolumeTest) DeleteVolume(vname string) error {
 	if ov.Err != nil {
 		return ov.Err
 	}
@@ -68,16 +69,16 @@ func EvaluateGetMayaClusterIP(mi MayaInterface) (string, error) {
 	return mi.GetMayaClusterIP(client)
 }
 
-func EvaluateCreateVsm(ovi OpenEBSVolumeInterface, vname string, size string) (string, error) {
-	return ovi.CreateVsm(vname, size)
+func EvaluateCreateVolume(ovi OpenEBSVolumeInterface, vs mayav1.VolumeSpec) (string, error) {
+	return ovi.CreateVolume(vs)
 }
 
-func EvaluateListVsm(ovi OpenEBSVolumeInterface, vname string, obj interface{}) error {
-	return ovi.ListVsm(vname, obj)
+func EvaluateListVolume(ovi OpenEBSVolumeInterface, vname string, obj interface{}) error {
+	return ovi.ListVolume(vname, obj)
 }
 
-func EvaluateDeleteVsm(ovi OpenEBSVolumeInterface, vname string) error {
-	return ovi.DeleteVsm(vname)
+func EvaluateDeleteVolume(ovi OpenEBSVolumeInterface, vname string) error {
+	return ovi.DeleteVolume(vname)
 }
 
 func TestGetMayaClusterIP(t *testing.T) {
@@ -133,8 +134,10 @@ func TestCreateVsm(t *testing.T) {
 	}
 
 	for _, c := range cases {
-
-		message, err := EvaluateCreateVsm(c.ovt, c.vname, c.size)
+		vs := mayav1.VolumeSpec{}
+		vs.Metadata.Name = c.vname
+		vs.Metadata.Labels.Storage = c.size
+		message, err := EvaluateCreateVolume(c.ovt, c.vname, c.size)
 
 		if !reflect.DeepEqual(err, c.expectedErr) {
 			t.Fatalf("Expected error %v got %v", c.expectedErr, err)
@@ -145,7 +148,7 @@ func TestCreateVsm(t *testing.T) {
 	}
 }
 
-func TestListVsm(t *testing.T) {
+func TestListVolume(t *testing.T) {
 	cases := []struct {
 		name        string
 		vname       string
@@ -174,7 +177,7 @@ func TestListVsm(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := EvaluateListVsm(c.ovt, c.vname, nil)
+		err := EvaluateListVolume(c.ovt, c.vname, nil)
 		if !reflect.DeepEqual(err, c.expectedErr) {
 			t.Fatalf("Expected error %v  got %v", c.expectedErr, err)
 		}
@@ -210,7 +213,7 @@ func TestDeleteVsm(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := EvaluateListVsm(c.ovt, c.vname, nil)
+		err := EvaluateListVolume(c.ovt, c.vname, nil)
 		if !reflect.DeepEqual(err, c.expectedErr) {
 			t.Fatalf("Expected error %v  got %v", c.expectedErr, err)
 		}

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package v1
 
-//VsmSpec holds the config for creating a VSM
-type VsmSpec struct {
+//VolumeSpec holds the config for creating a VSM
+type VolumeSpec struct {
 	Kind       string `yaml:"kind"`
 	APIVersion string `yaml:"apiVersion"`
 	Metadata   struct {
@@ -25,6 +25,7 @@ type VsmSpec struct {
 		Labels struct {
 			Storage      string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
 			StorageClass string `yaml:"k8s.io/storage-class"`
+			Namespace    string `yaml:"k8s.io/namespace"`
 		}
 	} `yaml:"metadata"`
 }

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -23,7 +23,7 @@ type VolumeSpec struct {
 	Metadata   struct {
 		Name   string `yaml:"name"`
 		Labels struct {
-			Storage      string `yaml:"openebs.io/capacity"`
+			Storage      string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
 			StorageClass string `yaml:"k8s.io/storage-class"`
 			Namespace    string `yaml:"k8s.io/namespace"`
 		}

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -23,7 +23,7 @@ type VolumeSpec struct {
 	Metadata   struct {
 		Name   string `yaml:"name"`
 		Labels struct {
-			Storage      string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
+			Storage      string `yaml:"openebs.io/capacity"`
 			StorageClass string `yaml:"k8s.io/storage-class"`
 			Namespace    string `yaml:"k8s.io/namespace"`
 		}


### PR DESCRIPTION
Why is this change required?
1. OpenEBS Provisioner should pass PVC namespace to maya_apiserver
2. Change VSM to Volume

What is changed?
1. VSM to Volume
2. OpenEBS Provisioner is passing PVC namespace to maya_apiserver

Fixes: 
- https://github.com/openebs/openebs/issues/784
- https://github.com/openebs/openebs/issues/787
- https://github.com/openebs/openebs/issues/727
- https://github.com/openebs/openebs/issues/810