### PR TITLE
 Allow openebs provisioner to identify namespace

### DIFF
--- a/openebs/README.md
+++ b/openebs/README.md
@@ -52,7 +52,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: openebs-provisioner
-  namespace: default
+  namespace: openebs
 spec:
   replicas: 1
   template:
@@ -70,6 +70,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 
 ```
 

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -55,8 +55,14 @@ type OpenEBSVolume struct{}
 func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, error) {
 	clusterIP := "127.0.0.1"
 
+	namespace := os.Getenv("OPENEBS_NAMESPACE")
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	glog.Info("OpenEBS volume provisioner namespace ", namespace)
 	//Fetch the Maya ClusterIP using the Maya API Server Service
-	sc, err := client.CoreV1().Services("default").Get("maya-apiserver-service", metav1.GetOptions{})
+	sc, err := client.CoreV1().Services(namespace).Get("maya-apiserver-service", metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Error getting maya-apiserver IP Address: %v", err)
 	}


### PR DESCRIPTION
OpenEBS provisioner should identify its own namespace and search for `maya-apiserver-service` in the same namespace. Here, we are reading the namespace of openebs-provisioner from `OPENEBS_NAMESPACE` env variable. If provisioner is unable to find `OPENEBS_NAMESPACE` variable then it should set namespace to `default`.

To set `OPENEBS_NAMESPACE` as namespace.
In openebs-operator.yaml add following:

```
env:
- name: OPENEBS_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace

```
We need to change namespace in `openebs-operator.yaml`  for `openebs-operator`, `maya-apiserver` deployment, `maya-apiserver-service` service & `openebs-provisioner` deployment.

fixes: openebs/openebs#306
fixes: kubernetes-incubator#424