### PR TITLE
Set the default lun number to 0 

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -166,7 +166,7 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 				ISCSI: &v1.ISCSIVolumeSource{
 					TargetPortal: targetPortal,
 					IQN:          iqn,
-					Lun:          1,
+					Lun:          0,
 					FSType:       "ext4",
 					ReadOnly:     false,
 				},


### PR DESCRIPTION
Support for running on CentOS required jiva (iscsi) target to be updated, which also starts exposing the LUN on 0 instead of 1. 

Related:
https://github.com/openebs/jiva/commit/b4c1011eda8070a184771999a74bde820675aafb

Fixes #https://github.com/openebs/openebs/issues/1076  