### PR TITLE
Add support for insecure/Non SSL connections on Kubernetes master

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -192,15 +192,16 @@ func main() {
 
 	flag.Parse()
 	flag.Set("logtostderr", "true")
-
-	// Create an InClusterConfig and use it to create a client for the controller
-	// to use to communicate with Kubernetes
-	var config *rest.Config
-	var err error
+	var (
+		config *rest.Config
+		err    error
+	)
 	if *master != "" || *kubeconfig != "" {
 		config, err = clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
 		fmt.Printf("Client config was built using flags: Address: '%s' Kubeconfig: '%s' \n", *master, *kubeconfig)
 	} else {
+		// Create an InClusterConfig and use it to create a client for the controller
+		// to use to communicate with Kubernetes
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"syscall"
 
@@ -35,13 +34,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
 	provisionerName = "openebs.io/provisioner-iscsi"
-	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
-	// It's currently still used and will be held for backwards compatibility
-	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
+)
+
+var (
+	master     = flag.String("master", "", "Master's URL to communicate with kubernetes-master if running from outside the cluster or if apiserver is allowing insecure/Non SSL connections.")
+	kubeconfig = flag.String("kubeconfig", "", "Absolute path to kubeconfig if running from outside the cluster.")
 )
 
 type openEBSProvisioner struct {
@@ -93,13 +95,7 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	volSize := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	volumeSpec.Metadata.Labels.Storage = volSize.String()
 
-	className := GetStorageClassName(options)
-
-	if className == nil {
-		glog.Errorf("Volume has no storage class specified")
-	} else {
-		volumeSpec.Metadata.Labels.StorageClass = *className
-	}
+	volumeSpec.Metadata.Labels.StorageClass = *options.PVC.Spec.StorageClassName
 	volumeSpec.Metadata.Labels.Namespace = options.PVC.Namespace
 	volumeSpec.Metadata.Name = options.PVName
 
@@ -109,15 +105,11 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		return nil, err
 	}
 
-	err = openebsVol.ListVolume(options.PVName, options.PVC.Namespace, &volume)
+	err = openebsVol.ListVolume(options.PVName, &volume)
 	if err != nil {
 		glog.Errorf("Error getting volume details: %v", err)
 		return nil, err
 	}
-
-	// Use annotations to specify the context using which the PV was created.
-	volAnnotations := make(map[string]string)
-	volAnnotations["openEBSProvisionerIdentity"] = p.identity
 
 	var iqn, targetPortal string
 
@@ -137,36 +129,12 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		return nil, fmt.Errorf("Invalid Access Modes: %v, Supported Access Modes: %v", options.PVC.Spec.AccessModes, p.GetAccessModes())
 	}
 
-	// The following will be used by the dashboard, to display links on PV page
-	userLinks := make([]string, 0)
-	localMonitoringURL := os.Getenv("OPENEBS_MONITOR_URL")
-	if localMonitoringURL != "" {
-		localMonitorLinkName := os.Getenv("OPENEBS_MONITOR_LINK_NAME")
-		if localMonitorLinkName == "" {
-			localMonitorLinkName = "monitor"
-		}
-		localMonitorVolKey := os.Getenv("OPENEBS_MONITOR_VOLKEY")
-		if localMonitorVolKey != "" {
-			localMonitoringURL += localMonitorVolKey + "=" + options.PVName
-		}
-		userLinks = append(userLinks, "\""+localMonitorLinkName+"\":\""+localMonitoringURL+"\"")
-	}
-	mayaPortalURL := os.Getenv("MAYA_PORTAL_URL")
-	if mayaPortalURL != "" {
-		mayaPortalLinkName := os.Getenv("MAYA_PORTAL_LINK_NAME")
-		if mayaPortalLinkName == "" {
-			mayaPortalLinkName = "maya"
-		}
-		userLinks = append(userLinks, "\""+mayaPortalLinkName+"\":\""+mayaPortalURL+"\"")
-	}
-	if len(userLinks) > 0 {
-		volAnnotations["alpha.dashboard.kubernetes.io/links"] = "{" + strings.Join(userLinks, ",") + "}"
-	}
-
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        options.PVName,
-			Annotations: volAnnotations,
+			Name: options.PVName,
+			Annotations: map[string]string{
+				"openEBSProvisionerIdentity": p.identity,
+			},
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
@@ -178,7 +146,7 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 				ISCSI: &v1.ISCSIVolumeSource{
 					TargetPortal: targetPortal,
 					IQN:          iqn,
-					Lun:          0,
+					Lun:          1,
 					FSType:       "ext4",
 					ReadOnly:     false,
 				},
@@ -204,7 +172,7 @@ func (p *openEBSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	}
 
 	// Issue a delete request to Maya API Server
-	err := openebsVol.DeleteVolume(volume.Name, volume.Spec.ClaimRef.Namespace)
+	err := openebsVol.DeleteVolume(volume.Name)
 	if err != nil {
 		glog.Errorf("Error while deleting volume: %v", err)
 		return err
@@ -227,7 +195,14 @@ func main() {
 
 	// Create an InClusterConfig and use it to create a client for the controller
 	// to use to communicate with Kubernetes
-	config, err := rest.InClusterConfig()
+	var config *rest.Config
+	var err error
+	if *master != "" || *kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
+		fmt.Printf("Client config was built using flags: Address: '%s' Kubeconfig: '%s' \n", *master, *kubeconfig)
+	} else {
+		config, err = rest.InClusterConfig()
+	}
 	if err != nil {
 		glog.Errorf("Failed to create config: %v", err)
 	}
@@ -260,13 +235,4 @@ func main() {
 		os.Exit(1) //Exit if provisioner not created.
 	}
 
-}
-
-// GetPersistentVolumeClass returns StorageClassName.
-func GetStorageClassName(options controller.VolumeOptions) *string {
-	// Use beta annotation first
-	if class, found := options.PVC.Annotations[BetaStorageClassAnnotation]; found {
-		return &class
-	}
-	return options.PVC.Spec.StorageClassName
 }


### PR DESCRIPTION
1. Why is this change necessary ?
- To support volume provisioning and discovering maya-apiserver on
   insecure/Non SSL connections to kubernetes master.

2. How does this change address the issue ?
- Add flags `--master` and `--kubeconfig`, Either of these can be used
  to communicate with the kubernetes-master.

3. How to verify this change ?
- Set-up your kubernetes cluster to allow insecure/Non SSL connections
** This is added only for testing purpose, please use secure connections otherwise. **
- Please verify whether your setup allows the insecure connections.[See](http://yasassriratnayake.blogspot.in/2017/05/how-to-allow-insecurenon-ssl.html)

4. What side effects does this change have ?
- Flags added is optional (either of `master` and `kubeconfig` can be
  used to connect with kubernetes master) and can be used as per
  requirement
- These flags can be passed in yaml file with the following fields
```
image: <openebs-k8s-provisioner-image>
command: ["openebs-provisioner"]
args:
- -master=<master's-ip>:8080
```

5. Other details
fix: openebs/openebs#1184