### PR TITLE
Add support for insecure/Non SSL connections on Kubernetes master

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -240,7 +240,7 @@ func main() {
 	} else {
 		// Create an InClusterConfig and use it to create a client for the controller
 		// to use to communicate with Kubernetes
-		config, err := rest.InClusterConfig()
+		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
 		glog.Errorf("Failed to create config: %v", err)


### PR DESCRIPTION
1. Why is this change necessary ?
- To support volume provisioning and discovering maya-apiserver on
   insecure/Non SSL connections to kubernetes master.

2. How does this change address the issue ?
- Add flags `--master` and `--kubeconfig`, Either of these can be used
  to communicate with the kubernetes-master.

3. How to verify this change ?
- Set-up your kubernetes cluster to allow insecure/Non SSL connections
** This is added only for testing purpose, please use secure connections
otherwise. **
- Please verify whether your setup allows the insecure
  connections.[See](http://yasassriratnayake.blogspot.in/2017/05/how-to-allow-insecurenon-ssl.html)

4. What side effects does this change have ?
- Flags added is optional (either of `master` and `kubeconfig` can be
  used to connect with kubernetes master) and can be used as per
  requirement
- These flags can be passed in yaml file with the following fields
```
image: <openebs-k8s-provisioner-image>
command: ["openebs-provisioner"]
args:
- -master=<master's-ip>:8080
```

5. Other details
fix: openebs/openebs#1184