### PR TITLE
Add support for insecure/non SSL connection on kubernetes via env vars

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -38,11 +38,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var (
-	master     = flag.String("master", "", "Master's URL to communicate with kubernetes-master if running from outside the cluster or if apiserver is allowing insecure/Non SSL connections.")
-	kubeconfig = flag.String("kubeconfig", "", "Absolute path to kubeconfig if running from outside the cluster.")
-)
-
 const (
 	provisionerName = "openebs.io/provisioner-iscsi"
 	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
@@ -231,12 +226,14 @@ func main() {
 	flag.Parse()
 	flag.Set("logtostderr", "true")
 	var (
-		config *rest.Config
-		err    error
+		config     *rest.Config
+		err        error
+		k8sMaster  = mayav1.K8sMasterENV()
+		kubeConfig = mayav1.KubeConfigENV()
 	)
-	if *master != "" || *kubeconfig != "" {
-		config, err = clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
-		fmt.Printf("Client config was built using flags: Address: '%s' Kubeconfig: '%s' \n", *master, *kubeconfig)
+	if len(k8sMaster) != 0 || len(kubeConfig) != 0 {
+		config, err = clientcmd.BuildConfigFromFlags(k8sMaster, kubeConfig)
+		fmt.Printf("Client config was built using flags: Address: '%s' Kubeconfig: '%s' \n", k8sMaster, kubeConfig)
 	} else {
 		// Create an InClusterConfig and use it to create a client for the controller
 		// to use to communicate with Kubernetes

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -232,8 +232,8 @@ func main() {
 		kubeConfig = mayav1.KubeConfigENV()
 	)
 	if len(k8sMaster) != 0 || len(kubeConfig) != 0 {
+		fmt.Printf("Build client config using k8s Master's Address: '%s' or Kubeconfig: '%s' \n", k8sMaster, kubeConfig)
 		config, err = clientcmd.BuildConfigFromFlags(k8sMaster, kubeConfig)
-		fmt.Printf("Client config was built using flags: Address: '%s' Kubeconfig: '%s' \n", k8sMaster, kubeConfig)
 	} else {
 		// Create an InClusterConfig and use it to create a client for the controller
 		// to use to communicate with Kubernetes

--- a/openebs/types/v1/env.go
+++ b/openebs/types/v1/env.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	"os"
+	"strings"
+)
+
+type ENVKey string
+
+const (
+	// KubeConfigENVK is the ENV key to fetch the kubeconfig
+	KubeConfigENVK ENVKey = "OPENEBS_IO_KUBE_CONFIG"
+
+	// K8sMasterENVK is the ENV key to fetch the K8s Master's Address
+	K8sMasterENVK ENVKey = "OPENEBS_IO_K8S_MASTER"
+)
+
+func KubeConfigENV() string {
+	val := GetEnv(KubeConfigENVK)
+	return val
+}
+
+func K8sMasterENV() string {
+	val := GetEnv(K8sMasterENVK)
+	return val
+}
+
+// GetEnv fetches the environment variable value from the machine's
+// environment
+func GetEnv(envKey ENVKey) string {
+	return strings.TrimSpace(os.Getenv(string(envKey)))
+}


### PR DESCRIPTION
1. Why is this change necessary ?
- To provide support for insecure/non SSL connections on kubernetes via
  k8s environment variables

2. How does this change address the issue ?
- Retrieve env variables directly from k8s env instead of getting as
  flags

3. How to verify this change ?
- Test the latest image with kubernetes cluster allowing insecure/Non SSL
  connections.

4. What side effects does this change have ?
- This commit adds a file env.go that has all the env variables defined
  and can be used in provisioner.

5. Other details
improvement: openebs/external-storage#30
fix: openebs/openebs#1184

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>