### PR TITLE
Setup minikube ci and remove the hard-coding for maya-apiserver-service. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,35 @@
 language: go
+env:
+- CHANGE_MINIKUBE_NONE_USER=true
 go:
   - 1.8.3
 services: docker
 
 install: true
 
+before_script:
+  # Download kubectl, which is a requirement for using minikube.
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.5/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  # Download minikube.
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.5
+  # Fix the kubectl context, as it's often stale.
+  - minikube update-context
+  # Wait for Kubernetes to be up and ready.
+  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+  # Download and initialize helm.
+  - ./openebs/ci/ubuntu-compile-nsenter.sh && sudo cp .tmp/util-linux-2.30.2/nsenter /usr/bin
+  - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+  - chmod 700 get_helm.sh
+  - ./get_helm.sh
+  - helm init
+
 script:
   - ./openebs-build.sh
+  # Verify that minkube is setup
+  - kubectl cluster-info
+  - kubectl get deployment
+  - ./openebs-ci.sh
 
 after_success:
   - ./openebs-deploy.sh

--- a/openebs-ci.sh
+++ b/openebs-ci.sh
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SRC_REPO=`pwd`
 DST_REPO="$GOPATH/src/github.com/kubernetes-incubator"
+export DST_REPO
 
-mkdir -p $DST_REPO
-cp -R $SRC_REPO/../external-storage $DST_REPO
-cd $DST_REPO/external-storage
-make openebs
+export DIMAGE="openebs/openebs-k8s-provisioner"
+cd $DST_REPO/external-storage/
+make push-openebs-provisioner
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
-
-
+$DST_REPO/external-storage/openebs/ci/travis-ci.sh
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 

--- a/openebs/ci/helm_install_openebs.sh
+++ b/openebs/ci/helm_install_openebs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+kubectl -n kube-system create sa tiller 
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller 
+kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}' 
+
+#Replace this with logic to wait till helm is initialized
+sleep 30
+kubectl get pods --all-namespaces 
+
+helm repo add openebs-charts https://openebs.github.io/charts/
+helm repo update
+helm install openebs-charts/openebs --set apiserver.imageTag="0.5.2",apiserver.replicas="1",provisioner.imageTag="ci",provisioner.replicas="1",jiva.replicas="1",rbacEnable="false"
+
+#Replace this with logic to wait/verify openebs control plane is initialized
+sleep 30
+kubectl get pods --all-namespaces -o yaml
+kubectl get svc --all-namespaces -o yaml

--- a/openebs/ci/travis-ci.sh
+++ b/openebs/ci/travis-ci.sh
@@ -14,14 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SRC_REPO=`pwd`
-DST_REPO="$GOPATH/src/github.com/kubernetes-incubator"
-
-mkdir -p $DST_REPO
-cp -R $SRC_REPO/../external-storage $DST_REPO
-cd $DST_REPO/external-storage
-make openebs
-
-
-
-
+$DST_REPO/external-storage/openebs/ci/helm_install_openebs.sh
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/openebs/ci/ubuntu-compile-nsenter.sh
+++ b/openebs/ci/ubuntu-compile-nsenter.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+#
+# Copyright 2017 The Jaeger Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -e
+
+sudo apt-get update
+sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+mkdir .tmp || true
+wget https://www.kernel.org/pub/linux/utils/util-linux/v2.30/util-linux-2.30.2.tar.gz -qO - | tar -xz -C .tmp/
+cd .tmp/util-linux-2.30.2 && ./autogen.sh && ./configure && make nsenter
+

--- a/openebs/pkg/v1/maya_api.go
+++ b/openebs/pkg/v1/maya_api.go
@@ -61,10 +61,16 @@ func (v OpenEBSVolume) GetMayaClusterIP(client kubernetes.Interface) (string, er
 	}
 
 	glog.Info("OpenEBS volume provisioner namespace ", namespace)
+
 	//Fetch the Maya ClusterIP using the Maya API Server Service
-	sc, err := client.CoreV1().Services(namespace).Get("maya-apiserver-service", metav1.GetOptions{})
+	mayaAPIServiceName := os.Getenv("OPENEBS_MAYA_SERVICE_NAME")
+	if mayaAPIServiceName == "" {
+		mayaAPIServiceName = "maya-apiserver-service"
+	}
+
+	sc, err := client.CoreV1().Services(namespace).Get(mayaAPIServiceName, metav1.GetOptions{})
 	if err != nil {
-		glog.Errorf("Error getting maya-apiserver IP Address: %v", err)
+		glog.Errorf("Error getting IP Address for service - %s : %v", mayaAPIServiceName, err)
 	}
 
 	clusterIP = sc.Spec.ClusterIP


### PR DESCRIPTION
Fixes https://github.com/openebs/openebs/issues/1227

Notes for reviewer:
- Includes the travis changes to include minikube/helm based setup instructions
- Make the maya-apiserver-service (default) name configurable. 
  * maya-apiservice name can be passed as ENV variable (OPENEBS_MAYA_SERVICE_NAME) to openebs-provisioner. 
  * maya-apiservice can use a custom name via helm chart. The change needs to be done at : https://github.com/openebs/openebs/blob/c9cefbc4624a5102a5e7ed42d88c0722382892ba/k8s/charts/openebs/templates/service-maya-apiserver.yaml#L6
  * The ENV has to be passed in this file: https://github.com/openebs/openebs/blob/master/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
