### PR TITLE
build ci image, latest only during releases

### DIFF
--- a/openebs/Makefile
+++ b/openebs/Makefile
@@ -26,7 +26,7 @@ push:
 
 deploy:
 	@cp openebs-provisioner buildscripts/docker/
-	@cd buildscripts/docker && sudo docker build -t ${DIMAGE}:latest .
+	@cd buildscripts/docker && sudo docker build -t ${DIMAGE}:ci .
 	@sh buildscripts/push
 
 clean:

--- a/openebs/buildscripts/push
+++ b/openebs/buildscripts/push
@@ -16,12 +16,12 @@
 
 set -e
 
-IMAGEID=$( sudo docker images -q ${DIMAGE}:latest )
+IMAGEID=$( sudo docker images -q ${DIMAGE}:ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   sudo docker login -u "${DNAME}" -p "${DPASS}"; 
-  sudo docker push ${DIMAGE}:latest ; 
+  sudo docker push ${DIMAGE}:ci ; 
   if [ ! -z "${TRAVIS_TAG}" ] ; 
   then
     #Push the release tag image to docker hub repository


### PR DESCRIPTION
Fixes https://github.com/openebs/openebs/issues/1240

- Similar to other images like m-apiserver and jiva, on every travis build, ci image is built and pushed to dockerhub. 
- latest image is built during release tagging. 


Signed-off-by: kmova <kiran.mova@openebs.io>