### PR TITLE
Support fstype other then ext4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ install: true
 
 before_script:
   # Download kubectl, which is a requirement for using minikube.
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.5/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.5
+  - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.9.4
   # Fix the kubectl context, as it's often stale.
   - minikube update-context
   # Wait for Kubernetes to be up and ready.

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -43,6 +43,8 @@ const (
 	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
 	// It's currently still used and will be held for backwards compatibility
 	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
+	//defaultFSType
+	defaultFSType = "ext4"
 )
 
 type openEBSProvisioner struct {
@@ -164,6 +166,16 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		volAnnotations["alpha.dashboard.kubernetes.io/links"] = "{" + strings.Join(userLinks, ",") + "}"
 	}
 
+	fsType := ""
+	for k, v := range options.Parameters {
+		switch strings.ToLower(k) {
+		case "openebs.io/fstype":
+			fsType = v
+		}
+	}
+	if len(fsType) == 0 {
+		fsType = defaultFSType
+	}
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        options.PVName,
@@ -180,7 +192,7 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 					TargetPortal: targetPortal,
 					IQN:          iqn,
 					Lun:          0,
-					FSType:       "ext4",
+					FSType:       fsType,
 					ReadOnly:     false,
 				},
 			},

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -47,6 +47,7 @@ const (
 	defaultFSType = "ext4"
 )
 
+// validFSType represents the valid fstype supported by openebs volume
 var validFSType = map[string]bool{"ext4": true, "xfs": true}
 
 type openEBSProvisioner struct {
@@ -290,7 +291,7 @@ func GetStorageClassName(options controller.VolumeOptions) *string {
 	return options.PVC.Spec.StorageClassName
 }
 
-// parseClassParameters parse storage class parameters to extract key/value
+// parseClassParameters parse storage class parameters to extract required key/value
 // pairs
 func parseClassParameters(params map[string]string) (string, error) {
 	var fsType string

--- a/openebs/openebs-provisioner_test.go
+++ b/openebs/openebs-provisioner_test.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 )
 
 func TestParseClassParameters(t *testing.T) {
-	//	cfgs := make(map[string]string)
-
 	cases := map[string]struct {
 		cfgs         map[string]string
 		expectErr    error
@@ -38,6 +37,61 @@ func TestParseClassParameters(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			fstype, err := parseClassParameters(tc.cfgs)
+			if !reflect.DeepEqual(err, tc.expectErr) {
+				t.Errorf("Expected %v, got %v", tc.expectErr, err)
+			}
+			if !reflect.DeepEqual(fstype, tc.expectfstype) {
+				t.Errorf("Expected %v, got %v", tc.expectfstype, fstype)
+			}
+		})
+	}
+}
+
+func TestParseClassENVParameters(t *testing.T) {
+	cases := map[string]struct {
+		cfgs         map[string]string
+		expectErr    error
+		expectfstype string
+	}{
+		"Dafault fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": ""},
+			expectErr:    nil,
+			expectfstype: "ext4",
+		},
+		"ext4 fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": "ext4"},
+			expectErr:    nil,
+			expectfstype: "ext4",
+		},
+		"ENV fstype nfs": {
+			cfgs:         map[string]string{"openebs.io/fstype": "nfs"},
+			expectErr:    nil,
+			expectfstype: "nfs",
+		},
+		"Invalid fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": "abcd"},
+			expectErr:    fmt.Errorf("Filesystem abcd is not supported"),
+			expectfstype: "",
+		},
+		"ENV fstype btrfs": {
+			cfgs:         map[string]string{"openebs.io/fstype": "btrfs"},
+			expectErr:    nil,
+			expectfstype: "btrfs",
+		},
+		"ENV fstype zfs": {
+			cfgs:         map[string]string{"openebs.io/fstype": "zfs"},
+			expectErr:    nil,
+			expectfstype: "zfs",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			os.Setenv("OPENEBS_VALID_FSTYPE", "nfs,btrfs,zfs")
+			defer os.Unsetenv("OPENEBS_VALID_FSTYPE")
+
 			fstype, err := parseClassParameters(tc.cfgs)
 			if !reflect.DeepEqual(err, tc.expectErr) {
 				t.Errorf("Expected %v, got %v", tc.expectErr, err)

--- a/openebs/openebs-provisioner_test.go
+++ b/openebs/openebs-provisioner_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestParseClassParameters(t *testing.T) {
+	//	cfgs := make(map[string]string)
+
+	cases := map[string]struct {
+		cfgs         map[string]string
+		expectErr    error
+		expectfstype string
+	}{
+		"Dafault fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": ""},
+			expectErr:    nil,
+			expectfstype: "ext4",
+		},
+		"ext4 fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": "ext4"},
+			expectErr:    nil,
+			expectfstype: "ext4",
+		},
+		"xfs fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": "xfs"},
+			expectErr:    nil,
+			expectfstype: "xfs",
+		},
+		"Invalid fstype": {
+			cfgs:         map[string]string{"openebs.io/fstype": "nfs"},
+			expectErr:    fmt.Errorf("Filesystem nfs is not supported"),
+			expectfstype: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fstype, err := parseClassParameters(tc.cfgs)
+			if !reflect.DeepEqual(err, tc.expectErr) {
+				t.Errorf("Expected %v, got %v", tc.expectErr, err)
+			}
+			if !reflect.DeepEqual(fstype, tc.expectfstype) {
+				t.Errorf("Expected %v, got %v", tc.expectfstype, fstype)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
This commit will extend the provisioner to support other filesystem i.e. `XFS, ext3` etc. `Ext4` will be the default fstype for openebs volumes. But can be changed via storageclass parameter key/value for example `openebs.io/fstype : xfs`

Note: `OPENEBS_VALID_FSTYPE` var can be passed from openebs provisioner pod to support any new valid fstype and use it via StorageClass. for example `export OPENEBS_VALID_FSTYPE="xfs,ext3,btrfs" `

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-percona
  provisioner: openebs.io/provisioner-iscsi
parameters:
  openebs.io/storage-pool: "default"
  openebs.io/jiva-replica-count: "1"
  openebs.io/volume-monitor: "true"
  openebs.io/capacity: 5G
  openebs.io/fstype: "xfs"
   ```
fixes: #https://github.com/openebs/openebs/issues/1446
#https://github.com/openebs/openebs/issues/1454 

**How to verify this change ?**

Tested the changes : 
1. Local kubernets cluster with perconaDB 
2. GKE cluster with MongoDB

```
$ kubectl get po
NAME                                                           READY     STATUS    RESTARTS   AGE
maya-apiserver-76fdf7c6c5-mjcvj                                1/1       Running   0          55m
openebs-provisioner-77c69f5df6-54trd                           1/1       Running   0          55m
percona                                                        1/1       Running   0          4m
pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc-ctrl-fd8898dc-l4h5l   1/1       Running   0          4m
pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc-rep-df5d44bc-4k8rz    1/1       Running   0          4m
snapshot-controller-5bc67594d7-x49jc                           2/2       Running   0          55m

```
```sh
sudo df -Th /dev/sdb
Filesystem     Type  Size  Used Avail Use% Mounted on
/dev/sdb       xfs   5.0G  252M  4.8G   5% /var/lib/kubelet/pods/32442f55-4e2e-11e8-9997-54e1ad0c1ccc/volumes/kubernetes.io~iscsi/pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc
```
```yaml
$ kubectl get pv pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    alpha.dashboard.kubernetes.io/links: '{"monitor":"http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1&var-OpenEBS=pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc","maya":"https://mayaonline.io/"}'
    openEBSProvisionerIdentity: 127.0.0.1
    pv.kubernetes.io/provisioned-by: openebs.io/provisioner-iscsi
  creationTimestamp: 2018-05-02T17:28:16Z
  finalizers:
  - kubernetes.io/pv-protection
  name: pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc
  resourceVersion: "7359"
  selfLink: /api/v1/persistentvolumes/pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc
  uid: 32a7924a-4e2e-11e8-9997-54e1ad0c1ccc
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 5G
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: demo-vol1-claim
    namespace: default
    resourceVersion: "7328"
    uid: 3244a601-4e2e-11e8-9997-54e1ad0c1ccc
  iscsi:
    fsType: xfs
    iqn: iqn.2016-09.com.openebs.jiva:pvc-3244a601-4e2e-11e8-9997-54e1ad0c1ccc
    iscsiInterface: default
    lun: 0
    targetPortal: 10.0.0.42:3260
  persistentVolumeReclaimPolicy: Delete
  storageClassName: openebs-percona
status:
  phase: Bound

```
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>