### PR TITLE
Add pvc label in volumeSpec struct

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -108,6 +108,7 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		volumeSpec.Metadata.Labels.StorageClass = *className
 	}
 	volumeSpec.Metadata.Labels.Namespace = options.PVC.Namespace
+	volumeSpec.Metadata.Labels.PersistantVolumeClaim = options.PVC.ObjectMeta.Name
 	volumeSpec.Metadata.Name = options.PVName
 
 	_, err := openebsVol.CreateVolume(volumeSpec)

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -108,7 +108,7 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		volumeSpec.Metadata.Labels.StorageClass = *className
 	}
 	volumeSpec.Metadata.Labels.Namespace = options.PVC.Namespace
-	volumeSpec.Metadata.Labels.PersistantVolumeClaim = options.PVC.ObjectMeta.Name
+	volumeSpec.Metadata.Labels.PersistentVolumeClaim = options.PVC.ObjectMeta.Name
 	volumeSpec.Metadata.Name = options.PVName
 
 	_, err := openebsVol.CreateVolume(volumeSpec)

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -23,9 +23,10 @@ type VolumeSpec struct {
 	Metadata   struct {
 		Name   string `yaml:"name"`
 		Labels struct {
-			Storage      string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
-			StorageClass string `yaml:"k8s.io/storage-class"`
-			Namespace    string `yaml:"k8s.io/namespace"`
+			Storage               string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
+			StorageClass          string `yaml:"k8s.io/storage-class"`
+			Namespace             string `yaml:"k8s.io/namespace"`
+			PersistantVolumeClaim string `yaml:"k8s.io/pvc"`
 		} `yaml:"labels"`
 	} `yaml:"metadata"`
 	CloneIP      string `yaml:"cloneIP"`

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -26,7 +26,7 @@ type VolumeSpec struct {
 			Storage               string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
 			StorageClass          string `yaml:"k8s.io/storage-class"`
 			Namespace             string `yaml:"k8s.io/namespace"`
-			PersistantVolumeClaim string `yaml:"k8s.io/pvc"`
+			PersistentVolumeClaim string `yaml:"k8s.io/pvc"`
 		} `yaml:"labels"`
 	} `yaml:"metadata"`
 	CloneIP      string `yaml:"cloneIP"`

--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -233,6 +233,7 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 	volSize := pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	volumeSpec.Metadata.Labels.Storage = volSize.String()
 	volumeSpec.Metadata.Labels.Namespace = pvc.Namespace
+	volumeSpec.Metadata.Labels.PersistentVolumeClaim = options.PVC.ObjectMeta.Name
 	volumeSpec.Metadata.Name = pvName
 
 	err = openebsVol.ListVolume(pvRefName, pvRefNamespace, &oldvolume)


### PR DESCRIPTION
For adding pvc label in deployment specification files 
  --> Added one more label PersistantVolumeClaim in volumeSpec struct which holds config for creating vsm.
 --> assigned value to the pvc label by fetching it from VolumeOptions struct which contains information of a volume.
