### PR TITLE
Hardening promote/clone API request

### DIFF
--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -38,8 +38,20 @@ type VolumeSpec struct {
 			ReplicaTopoKeyType    string `yaml:"volumeprovisioner.mapi.openebs.io/replica-topology-key-type,omitempty"`
 		} `yaml:"labels"`
 	} `yaml:"metadata"`
-	CloneIP      string `yaml:"cloneIP"`
-	SnapshotName string `yaml:"snapshotName"`
+	VolumeClone `yaml:"volumeClone"`
+}
+
+type VolumeClone struct {
+	// Defaults to false, true will enable the volume to be created as a clone
+	Clone bool `yaml:"clone,omitempty"`
+	// SourceVolume is snapshotted volume
+	SourceVolume string `yaml:"sourceVolume,omitempty"`
+	// CloneIP is the source controller IP which will be used to make a sync and rebuild
+	// request from the new clone replica.
+	CloneIP string `yaml:"cloneIP,omitempty"`
+	// SnapshotName name of snapshot which is getting promoted as persistent
+	// volume(this snapshot will be cloned to new volume).
+	SnapshotName string `yaml:"snapshotName,omitempty"`
 }
 
 // Volume is a command implementation struct

--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -193,11 +193,6 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 	parameters map[string]string,
 ) (*v1.PersistentVolumeSource, map[string]string, error) {
 
-	// GetMayaService get the maya-service endpoint
-	//err := GetMayaService()
-	//if err != nil {
-	//	return nil, nil, err
-	//}
 	if snapshotData == nil || snapshotData.Spec.OpenEBSSnapshot == nil {
 		return nil, nil, fmt.Errorf("Invalid Snapshot spec")
 	}
@@ -206,52 +201,12 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 	}
 
 	// restore snapshot to a PV
-	snapshotID := snapshotData.Spec.OpenEBSSnapshot.SnapshotID
-	pvRefName := snapshotData.Spec.PersistentVolumeRef.Name
-	var oldvolume, newvolume mayav1.Volume
+	var newvolume mayav1.Volume
 	var openebsVol mvol.OpenEBSVolume
-	volumeSpec := mayav1.VolumeSpec{}
 
-	pvRefNamespace, _, err := GetNameAndNameSpaceFromSnapshotName(snapshotData.Spec.VolumeSnapshotRef.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	// Get the source PV storage class name which will be passed
-	// to maya-apiserver to extract volume policy while restoring snapshot as
-	// new volume.
-	pvRefStorageClass, err := GetStorageClass(pvRefName)
-	if err != nil {
-		glog.Errorf("Error getting volume details: %v", err)
-	}
-	if len(pvRefStorageClass) == 0 {
-		glog.Errorf("Volume has no storage class specified")
-	} else {
-		volumeSpec.Metadata.Labels.StorageClass = pvRefStorageClass
-	}
-	glog.Infof("Using the Storage Class %s for dynamic provisioning", pvRefStorageClass)
+	volumeSpec := CreateCloneVolumeSpec(snapshotData, pvc, pvName)
 
-	volSize := pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	volumeSpec.Metadata.Labels.Storage = volSize.String()
-	volumeSpec.Metadata.Labels.Namespace = pvc.Namespace
-	volumeSpec.Metadata.Labels.PersistentVolumeClaim = pvc.ObjectMeta.Name
-	volumeSpec.Metadata.Name = pvName
-
-	err = openebsVol.ListVolume(pvRefName, pvRefNamespace, &oldvolume)
-	if err != nil {
-		glog.Errorf("Error getting volume details: %v", err)
-		return nil, nil, err
-	}
-	var cloneIP string
-	for key, value := range oldvolume.Metadata.Annotations.(map[string]interface{}) {
-		switch key {
-		case "vsm.openebs.io/controller-ips":
-			cloneIP = value.(string)
-		}
-	}
-	volumeSpec.CloneIP = cloneIP
-	volumeSpec.SnapshotName = snapshotID
-
-	err = openebsVol.CreateVolume(volumeSpec)
+	err := openebsVol.CreateVolume(volumeSpec)
 	if err != nil {
 		glog.Errorf("Error creating volume: %v", err)
 		return nil, nil, err
@@ -263,7 +218,6 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 	}
 
 	var iqn, targetPortal string
-
 	for key, value := range newvolume.Metadata.Annotations.(map[string]interface{}) {
 		switch key {
 		case "vsm.openebs.io/iqn":
@@ -274,11 +228,11 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 	}
 
 	if err != nil {
-		glog.Errorf("snapshot :%v restore failed, err:%v", snapshotID, err)
-		return nil, nil, fmt.Errorf("failed to restore %s, err: %v", snapshotID, err)
+		glog.Errorf("snapshot :%v restore failed, err:%v", snapshotData.Spec.OpenEBSSnapshot.SnapshotID, err)
+		return nil, nil, fmt.Errorf("failed to restore %s, err: %v", snapshotData.Spec.OpenEBSSnapshot.SnapshotID, err)
 	}
 
-	glog.V(1).Infof("snapshot restored successfully to: %v", snapshotID)
+	glog.V(1).Infof("snapshot restored successfully to: %v", snapshotData.Spec.OpenEBSSnapshot.SnapshotID)
 
 	pv := &v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIPersistentVolumeSource{
@@ -359,4 +313,46 @@ func GetNameAndNameSpaceFromSnapshotName(name string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid snapshot name")
 	}
 	return strs[0], strs[1], nil
+}
+
+// CreateVolumeSpec constructs the volumeSpec for volume create request
+func CreateCloneVolumeSpec(snapshotData *crdv1.VolumeSnapshotData,
+	pvc *v1.PersistentVolumeClaim,
+	pvName string,
+) mayav1.VolumeSpec {
+
+	// restore snapshot to a PV
+	// get the snaphot ID and source volume
+	snapshotID := snapshotData.Spec.OpenEBSSnapshot.SnapshotID
+	pvRefName := snapshotData.Spec.PersistentVolumeRef.Name
+	//pvRefNamespace := snapshotData.Spec.PersistentVolumeRef.Namespace
+	volumeSpec := mayav1.VolumeSpec{}
+
+	// Get the source PV storage class name which will be passed
+	// to maya-apiserver to extract volume policy while restoring snapshot as
+	// new volume.
+	pvRefStorageClass, err := GetStorageClass(pvRefName)
+	if err != nil {
+		glog.Errorf("Error getting volume details: %v", err)
+	}
+	if len(pvRefStorageClass) == 0 {
+		glog.Errorf("Volume has no storage class specified")
+	} else {
+		volumeSpec.Metadata.Labels.StorageClass = pvRefStorageClass
+	}
+	glog.Infof("Using the Storage Class %s for dynamic provisioning", pvRefStorageClass)
+
+	// construct volumespec for volume create request.
+	// Enable volume clone: set clone as true, enables openebs volume to be created
+	// as a clone volume
+	volSize := pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	volumeSpec.Metadata.Labels.Storage = volSize.String()
+	volumeSpec.Metadata.Labels.PersistentVolumeClaim = pvc.ObjectMeta.Name
+	volumeSpec.Metadata.Labels.Namespace = pvc.Namespace
+	volumeSpec.Metadata.Name = pvName
+	volumeSpec.SnapshotName = snapshotID
+	volumeSpec.Clone = true
+	volumeSpec.SourceVolume = pvRefName
+
+	return volumeSpec
 }


### PR DESCRIPTION
Enhance snaphot promote/clone request.
Now maya-apiserver will fetch all the infromation required for
volume clone using source persistent volume.
#### Old Clone volume request:
```
apiVersion: v1
metadata:
  name: pvc-c7494ccf-9a54-11e8-ba9b-54e1ad0c1ccc
  labels:
    volumeprovisioner.mapi.openebs.io/storage-size: 5Gi
    k8s.io/storage-class: openebs-default
    k8s.io/namespace: openebs
    k8s.io/pvc: demo-snap-vol-claim
    clone: true
    cloneIP: 10.13.1.34
    snapshotName: openebs-percona-pvc_fastfurious_1533654808264100890
```

#### New Clone volume request :
```
apiVersion: v1
metadata:
  name: pvc-c7494ccf-9a54-11e8-ba9b-54e1ad0c1ccc
  labels:
    volumeprovisioner.mapi.openebs.io/storage-size: 5Gi
    k8s.io/storage-class: openebs-default
    k8s.io/namespace: openebs
    k8s.io/pvc: demo-snap-vol-claim
volumeClone:
  clone: true
  sourceVolume: openebs-percona-pvc
  snapshotName: openebs-percona-pvc_fastfurious_1533654808264100890

```

Special Note: This PR is depends on https://github.com/openebs/maya/pull/370 to be merged....for travis CI to passed.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>