### PR TITLE
Retrieves the namespace from its VolumeSnapshotRef name  instead of 'PersistentVolumeRef.Namespace'.

### DIFF
--- a/snapshot/pkg/volume/openebs/processor_test.go
+++ b/snapshot/pkg/volume/openebs/processor_test.go
@@ -1,0 +1,37 @@
+package openebs
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestGetNameAndNameSpaceFromSnapshoName(t *testing.T) {
+	cases := map[string]struct {
+		name               string
+		expectErr          error
+		expectNamespace    string
+		expectSnapshotName string
+	}{
+
+		"SnapshotName with Namespace":    {"percona/fastfurious", nil, "percona", "fastfurious"},
+		"SnapshotName without Namespace": {"fastfurious", fmt.Errorf("invalid snapshot name"), "", ""},
+		"Invalid Unique SnapshotName":    {"k8s/percona/fastfurious", fmt.Errorf("invalid snapshot name"), "", ""},
+		"Nil SnapshotName":               {"", fmt.Errorf("invalid snapshot name"), "", ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			namespace, snapshotName, err := GetNameAndNameSpaceFromSnapshotName(tc.name)
+
+			if !reflect.DeepEqual(err, tc.expectErr) {
+				t.Errorf("Expected %v, got %v", tc.expectErr, err)
+			}
+			if !reflect.DeepEqual(namespace, tc.expectNamespace) {
+				t.Errorf("Expected %v, got %v", tc.expectNamespace, namespace)
+			}
+			if !reflect.DeepEqual(snapshotName, tc.expectSnapshotName) {
+				t.Errorf("Expected %v, got %v", tc.expectSnapshotName, snapshotName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Retrieves the volume namespace  from its `VolumeSnapshotRef.Name`, instead of `PersistentVolumeRef.Namespace`.
For exmaple SnapshotRef will be - "test-ns/snap1"

fixes: https://github.com/openebs/openebs/issues/1633

***Why this required:***
Change required b/c 'PersistentVolumeRef.Namespace contains' nil value, which was used earlier to pass the namespace.

```yaml
apiVersion: volumesnapshot.external-storage.k8s.io/v1
  kind: VolumeSnapshotData
  metadata:
    clusterName: ""
    creationTimestamp: 2018-01-24T06:59:48Z
    name: k8s-volume-snapshot-2a788036-00d4-11e8-9aa2-54e1ad0c1ccc
    namespace: ""
    resourceVersion: "1344"
    selfLink: /apis/volumesnapshot.external-storage.k8s.io/v1/k8s-volume-snapshot-2a788036-00d4-11e8-9aa2-54e1ad0c1ccc
    uid: 2a789f5a-00d4-11e8-acdc-54e1ad0c1ccc
  spec:
    openebsVolume:
      snapshotId: pvc-f1c1fdf2-00d2-11e8-acdc-54e1ad0c1ccc_1516777187978793304
    persistentVolumeRef:
      kind: PersistentVolume
      name: pvc-f1c1fdf2-00d2-11e8-acdc-54e1ad0c1ccc
    volumeSnapshotRef:
      kind: VolumeSnapshot
      name: default/snapshot-demo
  status:
    conditions:
    - lastTransitionTime: null
      message: Snapshot created successfully
      reason: ""
      status: "True"
      type: Ready
```

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>