### PR TITLE
Pass sts replica scheduling labels to apiserver

### DIFF
--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -113,8 +113,8 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	//Pass through labels from PVC to maya-apiserver
 	volumeSpec.Metadata.Labels.Application = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsApplication]
-	volumeSpec.Metadata.Labels.ReplicaTopoKeyDomain = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsREplicaTopKeyDomain]
-	volumeSpec.Metadata.Labels.ReplicaTopoKeyType = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsREplicaTopKeyType]
+	volumeSpec.Metadata.Labels.ReplicaTopoKeyDomain = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsReplicaTopKeyDomain]
+	volumeSpec.Metadata.Labels.ReplicaTopoKeyType = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsReplicaTopKeyType]
 
 	_, err := openebsVol.CreateVolume(volumeSpec)
 	if err != nil {

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -111,6 +111,11 @@ func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	volumeSpec.Metadata.Labels.PersistentVolumeClaim = options.PVC.ObjectMeta.Name
 	volumeSpec.Metadata.Name = options.PVName
 
+	//Pass through labels from PVC to maya-apiserver
+	volumeSpec.Metadata.Labels.Application = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsApplication]
+	volumeSpec.Metadata.Labels.ReplicaTopoKeyDomain = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsREplicaTopKeyDomain]
+	volumeSpec.Metadata.Labels.ReplicaTopoKeyType = options.PVC.ObjectMeta.GetLabels()[mayav1.PVCLabelsREplicaTopKeyType]
+
 	_, err := openebsVol.CreateVolume(volumeSpec)
 	if err != nil {
 		glog.Errorf("Error creating volume: %v", err)

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -18,8 +18,8 @@ package v1
 
 const (
 	PVCLabelsApplication = "volumeprovisioner.mapi.openebs.io/application"
-	PVCLabelsREplicaTopKeyDomain = "volumeprovisioner.mapi.openebs.io/replica-topology-key-domain"
-	PVCLabelsREplicaTopKeyType = "volumeprovisioner.mapi.openebs.io/replica-topology-key-type"
+	PVCLabelsReplicaTopKeyDomain = "volumeprovisioner.mapi.openebs.io/replica-topology-key-domain"
+	PVCLabelsReplicaTopKeyType = "volumeprovisioner.mapi.openebs.io/replica-topology-key-type"
 )
 
 //VolumeSpec holds the config for creating a OpenEBS Volume

--- a/openebs/types/v1/types.go
+++ b/openebs/types/v1/types.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package v1
 
-//VolumeSpec holds the config for creating a VSM
+const (
+	PVCLabelsApplication = "volumeprovisioner.mapi.openebs.io/application"
+	PVCLabelsREplicaTopKeyDomain = "volumeprovisioner.mapi.openebs.io/replica-topology-key-domain"
+	PVCLabelsREplicaTopKeyType = "volumeprovisioner.mapi.openebs.io/replica-topology-key-type"
+)
+
+//VolumeSpec holds the config for creating a OpenEBS Volume
 type VolumeSpec struct {
 	Kind       string `yaml:"kind"`
 	APIVersion string `yaml:"apiVersion"`
@@ -27,6 +33,9 @@ type VolumeSpec struct {
 			StorageClass          string `yaml:"k8s.io/storage-class"`
 			Namespace             string `yaml:"k8s.io/namespace"`
 			PersistentVolumeClaim string `yaml:"k8s.io/pvc"`
+			Application           string `yaml:"volumeprovisioner.mapi.openebs.io/application,omitempty"`
+			ReplicaTopoKeyDomain  string `yaml:"volumeprovisioner.mapi.openebs.io/replica-topology-key-domain,omitempty"`
+			ReplicaTopoKeyType    string `yaml:"volumeprovisioner.mapi.openebs.io/replica-topology-key-type,omitempty"`
 		} `yaml:"labels"`
 	} `yaml:"metadata"`
 	CloneIP      string `yaml:"cloneIP"`


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

In certain stateful application scenarios like - deploying a mongo-db application with a stateful application with 3 replicas, it is desirable to provision the PVs for each stateful instance in a default availability zone. The following labels can be attached to a stateful set by the user to indicate that PVs should be in different availability zones:

```
"volumeprovisioner.mapi.openebs.io/application": "mongo-app1"
"volumeprovisioner.mapi.openebs.io/replica-topology-key-domain": "failure-domain.beta.kubernetes.io"
"volumeprovisioner.mapi.openebs.io/replica-topology-key-type": "zone"
```
application label will be used as a selector, while the topology key can be specificied using the remaining two parameters. The above example uses the default - availability zone key.
