### PR TITLE
Use valid storageclass key in http header request

### DIFF
--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -59,6 +59,10 @@ const (
 
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
+
+	// StorageClassHeaderKey is the key to fetch name of StorageClass
+	// This key is present only in get request headers
+	StorageClassHeaderKey CASKey = "storageclass"
 )
 
 // CASVolumeKey is a typed string to represent CAS Volume related annotations'

--- a/openebs/pkg/volume/v1alpha1/volume.go
+++ b/openebs/pkg/volume/v1alpha1/volume.go
@@ -152,7 +152,7 @@ func (v CASVolume) ReadVolume(vname, namespace, storageclass string, obj interfa
 	req.Header.Set("namespace", namespace)
 	// passing storageclass info as a request header which will extracted by the
 	// Maya-apiserver to get the CAS template name
-	req.Header.Set(string(v1alpha1.StorageClassKey), storageclass)
+	req.Header.Set(string(v1alpha1.StorageClassHeaderKey), storageclass)
 
 	c := &http.Client{
 		Timeout: timeout,


### PR DESCRIPTION
HTTP headers do not support '/' character, hence the key `openebs.io/storageclass` is invalid. now using `storageclass` as key

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>