### PR TITLE
Make PV name unique and constant wrt to PVC

### DIFF
--- a/openebs/pkg/provisioner/cas_provision.go
+++ b/openebs/pkg/provisioner/cas_provision.go
@@ -19,7 +19,6 @@ package provisioner
 import (
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"os"
 
 	"github.com/golang/glog"
@@ -181,11 +180,4 @@ func (p *openEBSCASProvisioner) Delete(volume *v1.PersistentVolume) error {
 	}
 
 	return nil
-}
-
-// pvcHash generates a hash intenger from a string
-func pvcHash(s string) uint32 {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return h.Sum32()
 }

--- a/openebs/pkg/provisioner/common.go
+++ b/openebs/pkg/provisioner/common.go
@@ -2,6 +2,7 @@ package provisioner
 
 import (
 	"fmt"
+	"hash/fnv"
 	"os"
 	"strings"
 
@@ -65,4 +66,11 @@ func isValid(value string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// pvcHash generates a hash intenger from a string
+func pvcHash(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
 }

--- a/openebs/pkg/provisioner/common_test.go
+++ b/openebs/pkg/provisioner/common_test.go
@@ -53,7 +53,7 @@ func TestParseClassParameters(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			fstype, err := parseClassParameters(tc.cfgs)
+			fstype, err := ParseClassParameters(tc.cfgs)
 			if !reflect.DeepEqual(err, tc.expectErr) {
 				t.Errorf("Expected %v, got %v", tc.expectErr, err)
 			}
@@ -108,7 +108,7 @@ func TestParseClassENVParameters(t *testing.T) {
 			os.Setenv("OPENEBS_VALID_FSTYPE", "nfs,btrfs,zfs")
 			defer os.Unsetenv("OPENEBS_VALID_FSTYPE")
 
-			fstype, err := parseClassParameters(tc.cfgs)
+			fstype, err := ParseClassParameters(tc.cfgs)
 			if !reflect.DeepEqual(err, tc.expectErr) {
 				t.Errorf("Expected %v, got %v", tc.expectErr, err)
 			}
@@ -117,4 +117,30 @@ func TestParseClassENVParameters(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestpvcHash(t *testing.T) {
+	cases := map[string]struct {
+		str1      string
+		expectInt uint32
+	}{
+		"case1": {
+			str1:      "f30eda0f-a83d-11e8-9334-54e1ad0c1ccc",
+			expectInt: 744927970,
+		},
+		"case2": {
+			str1:      "",
+			expectInt: 2166136261,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			respInt := pvcHash(tc.str1)
+			if !reflect.DeepEqual(respInt, tc.expectInt) {
+				t.Errorf("Expected %v, got %v", tc.expectInt, respInt)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Earlier PV name was a combination of random strings which is
appended to pvc name is changes everytime if volume creation failed,
is creates new PV everytime.
This commit append the hash value of PVC name in PV name to make it
unique as well as constant.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>