### PR TITLE
Add fsType to PV from casVolume spec.

### DIFF
--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -128,6 +128,8 @@ type CASVolumeSpec struct {
 	Replicas string `json:"replicas"`
 	// CasType will hold the storage engine used to provision this volume
 	CasType string `json:"casType"`
+	// FSType willl hold the file system of the volume
+	FsType string `json:"fsType"`
 	// TODO add controller and replica status
 }
 

--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -128,9 +128,9 @@ type CASVolumeSpec struct {
 	Replicas string `json:"replicas"`
 	// CasType will hold the storage engine used to provision this volume
 	CasType string `json:"casType"`
-	// FSType willl hold the file system of the volume
+	// FSType will hold the file system of the volume
 	FSType string `json:"fsType"`
-	// LUN willl hold the lun of the volume
+	// LUN will hold the lun of the volume
 	Lun int32 `json:"lun"`
 	// TODO add controller and replica status
 }

--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -129,7 +129,9 @@ type CASVolumeSpec struct {
 	// CasType will hold the storage engine used to provision this volume
 	CasType string `json:"casType"`
 	// FSType willl hold the file system of the volume
-	FsType string `json:"fsType"`
+	FSType string `json:"fsType"`
+	// LUN willl hold the lun of the volume
+	Lun int32 `json:"lun"`
 	// TODO add controller and replica status
 }
 

--- a/openebs/pkg/provisioner/cas_provision.go
+++ b/openebs/pkg/provisioner/cas_provision.go
@@ -155,8 +155,8 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 				ISCSI: &v1.ISCSIPersistentVolumeSource{
 					TargetPortal: casVolume.Spec.TargetPortal,
 					IQN:          casVolume.Spec.Iqn,
-					Lun:          0,
-					FSType:       casVolume.Spec.FsType,
+					Lun:          casVolume.Spec.Lun,
+					FSType:       casVolume.Spec.FSType,
 					ReadOnly:     false,
 				},
 			},

--- a/openebs/pkg/provisioner/cas_provision.go
+++ b/openebs/pkg/provisioner/cas_provision.go
@@ -139,11 +139,6 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 	volAnnotations["openEBSProvisionerIdentity"] = p.identity
 	volAnnotations["openebs.io/cas-type"] = casVolume.Spec.CasType
 
-	fsType, err := ParseClassParameters(options.Parameters)
-	if err != nil {
-		return nil, err
-	}
-
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        PVName,
@@ -161,7 +156,7 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 					TargetPortal: casVolume.Spec.TargetPortal,
 					IQN:          casVolume.Spec.Iqn,
 					Lun:          0,
-					FSType:       fsType,
+					FSType:       casVolume.Spec.FsType,
 					ReadOnly:     false,
 				},
 			},


### PR DESCRIPTION
The volume read operation would return a CASVolume
object containing the filesystem type in its spec.

Update the spec in CASVolume struct.
Extract and put the fstype into PV spec.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>

Changes to be committed:
modified:   pkg/apis/openebs.io/v1alpha1/cas_volume.go
modified:   pkg/volume/volume.go