### PR TITLE
chore(provisioner): Extract and set annotations to PV object.

### DIFF
--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_snapshot.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_snapshot.go
@@ -20,6 +20,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// CASSnapshotKey is a typed string to represent CAS Snapshot related annotations'
+// or labels' keys
+//
+// Example 1 - Below is a sample StorageClass that makes use of a CASSnapshotKey
+// constant i.e. the cas template used to create a cas snapshot
+//
+// ```yaml
+// apiVersion: storage.k8s.io/v1
+// kind: StorageClass
+// metadata:
+//  name: openebs-standard
+//  annotations:
+//    cas.openebs.io/create-snapshot-template: cast-standard-0.8.0
+// provisioner: openebs.io/provisioner-iscsi
+// ```
+type CASSnapshotKey string
+
+const (
+	// CASTemplateKeyForSnapshotCreate is the key to fetch name of CASTemplate
+	// to create a CAS Snapshot
+	CASTemplateKeyForSnapshotCreate CASSnapshotKey = "cas.openebs.io/create-snapshot-template"
+
+	// CASTemplateKeyForSnapshotRead is the key to fetch name of CASTemplate
+	// to read a CAS Snapshot
+	CASTemplateKeyForSnapshotRead CASSnapshotKey = "cas.openebs.io/read-snapshot-template"
+
+	// CASTemplateKeyForSnapshotDelete is the key to fetch name of CASTemplate
+	// to delete a CAS Snapshot
+	CASTemplateKeyForSnapshotDelete CASSnapshotKey = "cas.openebs.io/delete-snapshot-template"
+
+	// CASTemplateKeyForSnapshotList is the key to fetch name of CASTemplate
+	// to list CAS Snapshots
+	CASTemplateKeyForSnapshotList CASSnapshotKey = "cas.openebs.io/list-snapshot-template"
+)
+
 // CASSnapshot represents a cas snapshot
 type CASSnapshot struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -60,6 +60,9 @@ const (
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
 
+	// CASTypeKey is the key to fetch storage engine for the volume
+	CASTypeKey CASKey = "openebs.io/cas-type"
+
 	// StorageClassHeaderKey is the key to fetch name of StorageClass
 	// This key is present only in get request headers
 	StorageClassHeaderKey CASKey = "storageclass"

--- a/openebs/pkg/provisioner/cas_provision.go
+++ b/openebs/pkg/provisioner/cas_provision.go
@@ -131,10 +131,9 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 	}
 
 	// Use annotations to specify the context using which the PV was created.
-	volAnnotations := make(map[string]string)
+	volAnnotations := GetVolAnnotations(casVolume)
 	volAnnotations = Setlink(volAnnotations, options.PVName)
 	volAnnotations["openEBSProvisionerIdentity"] = p.identity
-	volAnnotations["openebs.io/cas-type"] = casVolume.Spec.CasType
 
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -226,4 +225,22 @@ func Setlink(volAnnotations map[string]string, pvName string) map[string]string 
 	}
 
 	return volAnnotations
+}
+
+func GetVolAnnotations(casVolume v1alpha1.CASVolume) (volAnnotations map[string]string) {
+	volAnnotations = make(map[string]string)
+	volAnnotations[string(v1alpha1.CASTypeKey)] = casVolume.Spec.CasType
+	if casVolume.Annotations == nil {
+		return
+	}
+
+	volAnnotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForVolumeRead)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotCreate)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotCreate)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotDelete)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotDelete)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotRead)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotRead)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotList)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotList)]
+
+	return
 }

--- a/openebs/pkg/provisioner/cas_provision_test.go
+++ b/openebs/pkg/provisioner/cas_provision_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2018 The Kubernetes and OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes-incubator/external-storage/openebs/pkg/apis/openebs.io/v1alpha1"
+)
+
+func Test_getVolAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		casType     string
+		want        map[string]string
+	}{
+		"All Annotations are present in CASVolume object and castype is set": {
+			annotations: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate):   "createVolCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeDelete):   "deleteVolCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):     "readVolCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotCreate): "createSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotRead):   "readSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotDelete): "deleteSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotList):   "listSnapCAST",
+			},
+			casType: "jiva",
+			want: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate):   "createVolCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeDelete):   "deleteVolCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):     "readVolCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotCreate): "createSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotRead):   "readSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotDelete): "deleteSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotList):   "listSnapCAST",
+				string(v1alpha1.CASTypeKey):                      "jiva",
+			},
+		},
+		"Some Annotations are absent in CASVolume object and castype is set": {
+			annotations: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate): "createCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):   "readCAST",
+			},
+			casType: "jiva",
+			want: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate):   "createCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):     "readCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotCreate): "",
+				string(v1alpha1.CASTemplateKeyForSnapshotRead):   "",
+				string(v1alpha1.CASTemplateKeyForSnapshotDelete): "",
+				string(v1alpha1.CASTemplateKeyForSnapshotList):   "",
+				string(v1alpha1.CASTemplateKeyForVolumeDelete):   "",
+				string(v1alpha1.CASTypeKey):                      "jiva",
+			},
+		},
+		"Some Extra Annotations are present in CASVolume object and castype is set": {
+			annotations: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate):   "createCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):     "readCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotCreate): "createSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotRead):   "readSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotDelete): "deleteSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotList):   "listSnapCAST",
+				"extraAnnotation1":                               "val1",
+				"extraAnnotation2":                               "val2",
+			},
+			casType: "cstor",
+			want: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate):   "createCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):     "readCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotCreate): "createSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotRead):   "readSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotDelete): "deleteSnapCAST",
+				string(v1alpha1.CASTemplateKeyForSnapshotList):   "listSnapCAST",
+				string(v1alpha1.CASTemplateKeyForVolumeDelete):   "",
+				string(v1alpha1.CASTypeKey):                      "cstor",
+			},
+		},
+		"Annotations are missing in CASVolume object and castype is empty": {
+			annotations: map[string]string{},
+			casType:     "",
+			want: map[string]string{
+				string(v1alpha1.CASTemplateKeyForVolumeCreate):   "",
+				string(v1alpha1.CASTemplateKeyForVolumeRead):     "",
+				string(v1alpha1.CASTemplateKeyForVolumeDelete):   "",
+				string(v1alpha1.CASTemplateKeyForSnapshotCreate): "",
+				string(v1alpha1.CASTemplateKeyForSnapshotRead):   "",
+				string(v1alpha1.CASTemplateKeyForSnapshotDelete): "",
+				string(v1alpha1.CASTemplateKeyForSnapshotList):   "",
+				string(v1alpha1.CASTypeKey):                      "",
+			},
+		},
+		"Annotations field is nil in CASVolume object and castype is set": {
+			annotations: nil,
+			casType:     "cstor",
+			want: map[string]string{
+				string(v1alpha1.CASTypeKey): "cstor",
+			},
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			casVolume := v1alpha1.CASVolume{}
+			casVolume.Spec.CasType = mock.casType
+			casVolume.Annotations = mock.annotations
+			if got := getVolAnnotations(casVolume); !reflect.DeepEqual(got, mock.want) {
+				t.Errorf("getVolAnnotations() = %v, want %v", got, mock.want)
+			}
+		})
+	}
+}

--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -225,9 +225,8 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 
 	glog.V(1).Infof("snapshot restored successfully to: %v", snapshotData.Spec.OpenEBSSnapshot.SnapshotID)
 
-	vollabels := make(map[string]string)
+	vollabels := provisioner.GetVolAnnotations(newVolume)
 	vollabels = provisioner.Setlink(vollabels, pvName)
-	vollabels["openebs.io/cas-type"] = newVolume.Spec.CasType
 
 	pv := &v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIPersistentVolumeSource{
@@ -357,4 +356,22 @@ func CreateCloneVolumeSpec(snapshotData *crdv1.VolumeSnapshotData,
 	casVolume.CloneSpec.SourceVolume = pvRefName
 
 	return casVolume, pvRefStorageClass
+}
+
+func getVolAnnotations(casVolume v1alpha1.CASVolume) (volAnnotations map[string]string) {
+	volAnnotations = make(map[string]string)
+	volAnnotations[string(v1alpha1.CASTypeKey)] = casVolume.Spec.CasType
+	if casVolume.Annotations == nil {
+		return
+	}
+
+	volAnnotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForVolumeRead)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotCreate)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotCreate)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotDelete)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotDelete)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotRead)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotRead)]
+	volAnnotations[string(v1alpha1.CASTemplateKeyForSnapshotList)] = casVolume.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotList)]
+
+	return
 }


### PR DESCRIPTION
Add logic to save cast annotations obtained from CASVolume to PV object.

Signed-off-by: princerachit <prince.rachit@mayadata.io>