### PR TITLE
chore(provisioner): Add cas type and storage class in pv label.

### DIFF
--- a/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/openebs/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -60,6 +60,9 @@ const (
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
 
+	// CASTypeKey is the key to fetch storage engine for the volume
+	CASTypeKey CASKey = "openebs.io/cas-type"
+
 	// StorageClassHeaderKey is the key to fetch name of StorageClass
 	// This key is present only in get request headers
 	StorageClassHeaderKey CASKey = "storageclass"

--- a/openebs/pkg/provisioner/cas_provision.go
+++ b/openebs/pkg/provisioner/cas_provision.go
@@ -135,11 +135,11 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 	volAnnotations := make(map[string]string)
 	volAnnotations = Setlink(volAnnotations, options.PVName)
 	volAnnotations["openEBSProvisionerIdentity"] = p.identity
-	volAnnotations[string(v1alpha1.CASConfigKey)] = casVolume.Spec.CasType
+	volAnnotations[string(v1alpha1.CASTypeKey)] = casVolume.Spec.CasType
 	fstype := casVolume.Spec.FSType
 
 	labels := make(map[string]string)
-	labels[string(v1alpha1.CASConfigKey)] = casVolume.Spec.CasType
+	labels[string(v1alpha1.CASTypeKey)] = casVolume.Spec.CasType
 	labels[string(v1alpha1.StorageClassKey)] = *options.PVC.Spec.StorageClassName
 
 	var volumeMode *v1.PersistentVolumeMode

--- a/openebs/pkg/provisioner/cas_provision.go
+++ b/openebs/pkg/provisioner/cas_provision.go
@@ -135,8 +135,12 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 	volAnnotations := make(map[string]string)
 	volAnnotations = Setlink(volAnnotations, options.PVName)
 	volAnnotations["openEBSProvisionerIdentity"] = p.identity
-	volAnnotations["openebs.io/cas-type"] = casVolume.Spec.CasType
+	volAnnotations[string(v1alpha1.CASConfigKey)] = casVolume.Spec.CasType
 	fstype := casVolume.Spec.FSType
+
+	labels := make(map[string]string)
+	labels[string(v1alpha1.CASConfigKey)] = casVolume.Spec.CasType
+	labels[string(v1alpha1.StorageClassKey)] = *options.PVC.Spec.StorageClassName
 
 	var volumeMode *v1.PersistentVolumeMode
 	volumeMode = options.PVC.Spec.VolumeMode
@@ -149,6 +153,7 @@ func (p *openEBSCASProvisioner) Provision(options controller.VolumeOptions) (*v1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        options.PVName,
 			Annotations: volAnnotations,
+			Labels:      labels,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,

--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -226,7 +226,7 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 
 	vollabels := make(map[string]string)
 	vollabels = provisioner.Setlink(vollabels, pvName)
-	vollabels[string(v1alpha1.CASConfigKey)] = newVolume.Spec.CasType
+	vollabels[string(v1alpha1.CASTypeKey)] = newVolume.Spec.CasType
 	vollabels[string(v1alpha1.StorageClassKey)] = class
 
 	pv := &v1.PersistentVolumeSource{

--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -31,7 +31,6 @@ import (
 	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (
@@ -227,7 +226,8 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 
 	vollabels := make(map[string]string)
 	vollabels = provisioner.Setlink(vollabels, pvName)
-	vollabels["openebs.io/cas-type"] = newVolume.Spec.CasType
+	vollabels[string(v1alpha1.CASConfigKey)] = newVolume.Spec.CasType
+	vollabels[string(v1alpha1.StorageClassKey)] = class
 
 	pv := &v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIPersistentVolumeSource{
@@ -278,8 +278,8 @@ func GetMayaService() error {
 
 // GetPersistentVolumeClass returns StorageClassName
 func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
-	// Use beta annotation first
-	if class, found := volume.Annotations[core.BetaStorageClassAnnotation]; found {
+	// Use label first
+	if class, found := volume.Labels[string(v1alpha1.StorageClassKey)]; found {
 		return class
 	}
 


### PR DESCRIPTION
Add sc and castype of an openebs volume to the label of the created pv.
These labels are later used for cloning.

Signed-off-by: princerachit <prince.rachit@mayadata.io>