### PR TITLE
refactor(ci): support both docker and quay images for ci

### DIFF
--- a/openebs/ci/snapshot/snapshot_deploy.sh
+++ b/openebs/ci/snapshot/snapshot_deploy.sh
@@ -22,6 +22,11 @@ if [ ${CI_TAG} != "ci" ]; then
   sudo docker tag openebs/snapshot-provisioner:ci openebs/snapshot-provisioner:${CI_TAG}
 fi
 
+#Tag the images with quay.io, since the operator can either have quay or docker images
+sudo docker tag openebs/openebs-k8s-provisioner:ci quay.io/openebs/openebs-k8s-provisioner:${CI_TAG}
+sudo docker tag openebs/snapshot-controller:ci quay.io/openebs/snapshot-controller:${CI_TAG}
+sudo docker tag openebs/snapshot-provisioner:ci quay.io/openebs/snapshot-provisioner:${CI_TAG}
+
 kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/${CI_BRANCH}/k8s/openebs-operator.yaml
 
 for i in $(seq 1 50) ; do


### PR DESCRIPTION
integration (or ci) tests are done by applying the openebs-operator
fetched from openebs/openebs repo. This file can either have images
specified as quay or docker.

Before applying the operator yaml, retag the local docker ci images
with quay tags.

Signed-off-by: kmova <kiran.mova@openebs.io>
(cherry picked from commit 1e28647ee462c5c21415c03e78b851b4e333c0ff)