### PR TITLE
[cherry-pick] feat(volumesnapshotdata) Adds capacity field in volumesnapshotdata (#88)

### DIFF
--- a/snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
+++ b/snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
@@ -101,7 +101,7 @@ func (p *snapshotProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 	}
 	snapshotName, ok := options.PVC.Annotations[crdclient.SnapshotPVCAnnotation]
 	if !ok {
-		return nil, fmt.Errorf("snapshot annotation not found on PV")
+		return nil, fmt.Errorf("snapshot annotation not found on PVC")
 	}
 
 	var snapshot crdv1.VolumeSnapshot
@@ -112,7 +112,7 @@ func (p *snapshotProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 		Do().Into(&snapshot)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve VolumeSnapshot %s: %v", snapshotName, err)
+		return nil, fmt.Errorf("failed to retrieve VolumeSnapshot %s in namespace %s: %v", snapshotName, options.PVC.Namespace, err)
 	}
 	// FIXME: should also check if any VolumeSnapshotData points to this VolumeSnapshot
 	if len(snapshot.Spec.SnapshotDataName) == 0 {

--- a/snapshot/pkg/apis/crd/v1/types.go
+++ b/snapshot/pkg/apis/crd/v1/types.go
@@ -230,6 +230,8 @@ type CinderVolumeSnapshotSource struct {
 type OpenEBSVolumeSnapshotSource struct {
 	// Unique id of the cinder volume snapshot resource. Used to identify the snapshot in OpenStack
 	SnapshotID string `json:"snapshotId"`
+	// Capacity will holds the size of the snapshot
+	Capacity string `json:"capacity"`
 }
 
 // GCEPersistentDiskSnapshotSource is GCE PD volume snapshot source

--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -102,9 +102,11 @@ func (h *openEBSPlugin) SnapshotCreate(snapshot *crdv1.VolumeSnapshot, pv *v1.Pe
 		}
 	}
 
+	sizeResource := pv.Spec.Capacity[v1.ResourceName(v1.ResourceStorage)]
 	res := &crdv1.VolumeSnapshotDataSource{
 		OpenEBSSnapshot: &crdv1.OpenEBSVolumeSnapshotSource{
 			SnapshotID: snapshotName,
+			Capacity:   sizeResource.String(),
 		},
 	}
 	return res, &cond, err


### PR DESCRIPTION
This PR adds capacity field under Spec in volumesnapshotdata
**kubectl describe volumesnapshotdata <volumesnapshotdata_name>:**
```
Name:         k8s-volume-snapshot-a61dddcc-496f-11e9-bca1-0242ac110005
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  volumesnapshot.external-storage.k8s.io/v1
Kind:         VolumeSnapshotData
Metadata:
  Creation Timestamp:  2019-03-18T11:19:08Z
  Generation:          1
  Resource Version:    814
  Self Link:           /apis/volumesnapshot.external-storage.k8s.io/v1/volumesnapshotdatas/k8s-volume-snapshot-a61dddcc-496f-11e9-bca1-0242ac110005
  UID:                 a61e2b86-496f-11e9-a465-28d2440cdb59
Spec:
  Openebs Volume:
    Capacity:     5G
    Snapshot Id:  pvc-7f7dbc3e-496f-11e9-a465-28d2440cdb59_snapshot-demo-cstor_1552907947683679481
  Persistent Volume Ref:
    Kind:  PersistentVolume
    Name:  pvc-7f7dbc3e-496f-11e9-a465-28d2440cdb59
  Volume Snapshot Ref:
    Kind:  VolumeSnapshot
    Name:  default/snapshot-demo-cstor-a54a9955-496f-11e9-a465-28d2440cdb59
Status:
  Conditions:
    Last Transition Time:  2019-03-18T11:19:08Z
    Message:               Snapshot created successfully
    Reason:                
    Status:                True
    Type:                  Ready
  Creation Timestamp:      <nil>
Events:                    <none>
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>