### PR TITLE
fix(clone): get fsType from the Storage class annotation

### DIFF
--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -252,7 +252,7 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 			TargetPortal: newVolume.Spec.TargetPortal,
 			IQN:          newVolume.Spec.Iqn,
 			Lun:          0,
-			FSType:       "ext4",
+			FSType:       newVolume.Spec.FSType,
 			ReadOnly:     false,
 		},
 	}


### PR DESCRIPTION
Commit changes to get the fstype info from the CASVolume
resource which populated using via CAS config in StorageClass annotations and remove the hardcoded default `ext4` fstype

fixes:https://github.com/openebs/openebs/issues/2809

### StorageClass with `xfs` FStype

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-sparse-auto
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: "sparse-claim-auto"
      - name: ReplicaCount
        value: "1"
      - name: FSType
        value: "xfs"
provisioner: openebs.io/provisioner-iscsi
reclaimPolicy: Retain
```

```sh
kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                         STORAGECLASS                REASON   AGE
pvc-08a28963-12a6-4491-aa76-5fa30460acdd   5Gi        RWO            Retain           Bound    default/cstor-test            openebs-cstor-sparse-auto            8m29s
pvc-6810d7bd-f0ff-4a6d-a776-ae9729a66572   5Gi        RWO            Delete           Bound    default/demo-snap-vol-claim   openebs-snapshot-promoter            6m20s

```
###  Source PersistentVolume
```yaml
kubectl get pv pvc-08a28963-12a6-4491-aa76-5fa30460acdd -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    openEBSProvisionerIdentity: 127.0.0.1
    openebs.io/cas-type: cstor
    pv.kubernetes.io/provisioned-by: openebs.io/provisioner-iscsi
  creationTimestamp: "2020-01-10T13:32:07Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    openebs.io/cas-type: cstor
    openebs.io/storageclass: openebs-cstor-sparse-auto
  name: pvc-08a28963-12a6-4491-aa76-5fa30460acdd
  resourceVersion: "1109"
  selfLink: /api/v1/persistentvolumes/pvc-08a28963-12a6-4491-aa76-5fa30460acdd
  uid: 525f6a90-24bd-4d14-9aa1-e71e80a4f75d
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 5Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: cstor-test
    namespace: default
    resourceVersion: "1083"
    uid: 08a28963-12a6-4491-aa76-5fa30460acdd
  iscsi:
    fsType: xfs
    iqn: iqn.2016-09.com.openebs.cstor:pvc-08a28963-12a6-4491-aa76-5fa30460acdd
    iscsiInterface: default
    lun: 0
    targetPortal: 10.0.0.150:3260
  persistentVolumeReclaimPolicy: Retain
  storageClassName: openebs-cstor-sparse-auto
  volumeMode: Filesystem
status:
  phase: Bound

```

### Clone PersistentVolume
```yaml
 kubectl get pv pvc-6810d7bd-f0ff-4a6d-a776-ae9729a66572 -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: volumesnapshot.external-storage.k8s.io/snapshot-promoter
    snapshotProvisionerIdentity: volumesnapshot.external-storage.k8s.io/snapshot-promoter
  creationTimestamp: "2020-01-10T13:34:16Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    openebs.io/cas-type: cstor
    openebs.io/storageclass: openebs-cstor-sparse-auto
  name: pvc-6810d7bd-f0ff-4a6d-a776-ae9729a66572
  resourceVersion: "1340"
  selfLink: /api/v1/persistentvolumes/pvc-6810d7bd-f0ff-4a6d-a776-ae9729a66572
  uid: af1cc510-47b3-415e-8204-0f759782c402
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 5Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: demo-snap-vol-claim
    namespace: default
    resourceVersion: "1313"
    uid: 6810d7bd-f0ff-4a6d-a776-ae9729a66572
  iscsi:
    fsType: xfs
    iqn: iqn.2016-09.com.openebs.cstor:pvc-6810d7bd-f0ff-4a6d-a776-ae9729a66572
    iscsiInterface: default
    lun: 0
    targetPortal: 10.0.0.70:3260
  persistentVolumeReclaimPolicy: Delete
  storageClassName: openebs-snapshot-promoter
  volumeMode: Filesystem
status:
  phase: Bound

```
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>