### PR TITLE
fix(clone): get fsType from the Storage class annotation

### DIFF
--- a/snapshot/pkg/volume/openebs/processor.go
+++ b/snapshot/pkg/volume/openebs/processor.go
@@ -252,7 +252,7 @@ func (h *openEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData,
 			TargetPortal: newVolume.Spec.TargetPortal,
 			IQN:          newVolume.Spec.Iqn,
 			Lun:          0,
-			FSType:       "ext4",
+			FSType:       newVolume.Spec.FSType,
 			ReadOnly:     false,
 		},
 	}


### PR DESCRIPTION
Commit changes to get the fstype info from the CASVolume resource which populated using via CAS config in StorageClass annotations.

cherry-pick : #102 

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>