### PR TITLE
chore(build): use alpine as base image for snapshot controller

### DIFF
--- a/snapshot/deploy/docker/controller/Dockerfile
+++ b/snapshot/deploy/docker/controller/Dockerfile
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:glibc
-COPY snapshot-controller /bin/snapshot-controller
+FROM alpine:3.6
+
+RUN apk add --no-cache \
+    bash \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat \
+    ca-certificates
+
+COPY snapshot-controller /
 # Root CA certificates
 COPY etc /etc
 COPY usr /usr
-ENTRYPOINT ["/bin/snapshot-controller"]
+ENTRYPOINT ["/snapshot-controller"]

--- a/snapshot/deploy/docker/provisioner/Dockerfile
+++ b/snapshot/deploy/docker/provisioner/Dockerfile
@@ -12,9 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:glibc
-COPY snapshot-provisioner /bin/snapshot-provisioner
+FROM alpine:3.6
+
+RUN apk add --no-cache \
+    bash \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat \
+    ca-certificates
+
+
+COPY snapshot-provisioner /
 # Root CA certificates
 COPY etc /etc
 COPY usr /usr
-ENTRYPOINT ["/bin/snapshot-provisioner"]
+ENTRYPOINT ["/snapshot-provisioner"]


### PR DESCRIPTION
commits uses the alpine as a base image to build snapshot
controller and snapshot provisioner images, due to
unsupported and unscannable container image layer error in
quay and other images repo while scanning

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>