### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,14 @@ script:
   # v1.9.0-custom => should be v1.9.x-custom
   # v1.9.1-custom => should be v1.9.x-custom
   # Convert the TRAVIS_TAG to the corresponding release branch.
-  - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/external-storage" ]; then
+  #
+  # Allow for building forked openebs pipelines. 
+  # Tag the downstream repos under current repo org. 
+  - if [ -z $REPO_ORG ]; then
+      REPO_ORG=$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f1);
+      export REPO_ORG;
+    fi
+  - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "$REPO_ORG/external-storage" ]; then
       TAG_SUFFIX=$(echo "$TRAVIS_TAG" | cut -d'-' -f2);
       if [ "$TAG_SUFFIX" == "$TRAVIS_TAG" ] || [[ $TAG_SUFFIX =~ ^RC ]]; then
         REL_SUFFIX="";
@@ -91,7 +98,7 @@ script:
 
       REL_BRANCH=$(echo $(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x$REL_SUFFIX);
 
-      ./openebs/buildscripts/git-release "openebs/maya" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      ./openebs/buildscripts/git-release "$REPO_ORG/maya" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
     fi
 
 after_success:

--- a/openebs-build.sh
+++ b/openebs-build.sh
@@ -27,7 +27,6 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 echo "Building snapshot-controller and snapshot-provisioner"
 cd $DST_REPO/external-storage/snapshot
-export REGISTRY="openebs/"
 export VERSION="ci"
 make container
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/openebs-deploy.sh
+++ b/openebs-deploy.sh
@@ -17,6 +17,10 @@
 # Determine the arch/os we're building for
 ARCH=$(uname -m)
 
+if [ -z "${IMAGE_ORG}" ]; then
+	IMAGE_ORG="openebs"
+fi
+
 if [ "${ARCH}" = "x86_64" ]; then
 	export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner"
 	./openebs/buildscripts/push

--- a/openebs-deploy.sh
+++ b/openebs-deploy.sh
@@ -18,22 +18,22 @@
 ARCH=$(uname -m)
 
 if [ "${ARCH}" = "x86_64" ]; then
-	export DIMAGE="openebs/openebs-k8s-provisioner"
+	export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner"
 	./openebs/buildscripts/push
 
-	export DIMAGE="openebs/snapshot-controller"
+	export DIMAGE="${IMAGE_ORG}/snapshot-controller"
 	./openebs/buildscripts/push
 
-	export DIMAGE="openebs/snapshot-provisioner"
+	export DIMAGE="${IMAGE_ORG}/snapshot-provisioner"
 	./openebs/buildscripts/push
 elif [ "${ARCH}" = "aarch64" ]; then
-	export DIMAGE="openebs/openebs-k8s-provisioner-arm64"
+	export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner-arm64"
 	./openebs/buildscripts/push
 
-	export DIMAGE="openebs/snapshot-controller-arm64"
+	export DIMAGE="${IMAGE_ORG}/snapshot-controller-arm64"
 	./openebs/buildscripts/push
 
-	export DIMAGE="openebs/snapshot-provisioner-arm64"
+	export DIMAGE="${IMAGE_ORG}/snapshot-provisioner-arm64"
 	./openebs/buildscripts/push
 else
 	echo "${ARCH} is not supported"

--- a/openebs/Makefile
+++ b/openebs/Makefile
@@ -42,10 +42,33 @@ else
 endif
 export BASEIMAGE
 
+ifeq (${IMAGE_ORG}, )
+  IMAGE_ORG=openebs
+  export IMAGE_ORG
+endif
+
+# Specify the date of build
+DBUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Specify the docker arg for repository url
+ifeq (${DBUILD_REPO_URL}, )
+  DBUILD_REPO_URL="https://github.com/openebs/external-storage"
+  export DBUILD_REPO_URL
+endif
+
+# Specify the docker arg for website url
+ifeq (${DBUILD_SITE_URL}, )
+  DBUILD_SITE_URL="https://openebs.io"
+  export DBUILD_SITE_URL
+endif
+
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
+
+
 ifeq (${ARCH},linux_arm64)
-  DIMAGE:="openebs/openebs-k8s-provisioner-arm64"
+  DIMAGE:="${IMAGE_ORG}/openebs-k8s-provisioner-arm64"
 else
-  DIMAGE:="openebs/openebs-k8s-provisioner"
+  DIMAGE:="${IMAGE_ORG}/openebs-k8s-provisioner"
 endif
 export DIMAGE
 
@@ -58,7 +81,7 @@ build:
 
 image: build
 	@cp openebs-provisioner buildscripts/docker/
-	@cd buildscripts/docker && sudo docker build -t ${DIMAGE}:ci --build-arg BASE_IMAGE=${BASEIMAGE} .
+	@cd buildscripts/docker && sudo docker build -t ${DIMAGE}:ci ${DBUILD_ARGS} --build-arg BASE_IMAGE=${BASEIMAGE} .
 
 .PHONY: container
 container: image

--- a/openebs/buildscripts/docker/Dockerfile
+++ b/openebs/buildscripts/docker/Dockerfile
@@ -15,4 +15,17 @@
 ARG BASE_IMAGE=ubuntu:16.04
 FROM $BASE_IMAGE
 COPY openebs-provisioner /
+
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="openebs-k8s-provisioner"
+LABEL org.label-schema.description="OpenEBS Dynamic cStor and Jiva Provisioner"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
 CMD ["/openebs-provisioner"]

--- a/snapshot/Makefile
+++ b/snapshot/Makefile
@@ -29,8 +29,31 @@ export XC_ARCH
 ARCH:=${XC_OS}_${XC_ARCH}
 export ARCH
 
+ifeq (${IMAGE_ORG}, )
+  IMAGE_ORG=openebs
+  export IMAGE_ORG
+endif
+
+# Specify the date of build
+DBUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Specify the docker arg for repository url
+ifeq (${DBUILD_REPO_URL}, )
+  DBUILD_REPO_URL="https://github.com/openebs/external-storage"
+  export DBUILD_REPO_URL
+endif
+
+# Specify the docker arg for website url
+ifeq (${DBUILD_SITE_URL}, )
+  DBUILD_SITE_URL="https://openebs.io"
+  export DBUILD_SITE_URL
+endif
+
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
+
+
 ifeq ($(REGISTRY),)
-	REGISTRY = quay.io/external_storage/
+	REGISTRY = ${IMAGE_ORG}/
 endif
 ifeq ($(VERSION),)
 	VERSION = latest
@@ -78,9 +101,9 @@ container-quick:
 	# Copy the root CA certificates -- cloudproviders need them
 	cp -Rf deploy/ca-certificates/* deploy/docker/controller/.
 	cp -Rf deploy/ca-certificates/* deploy/docker/provisioner/.
-	docker build -t $(MUTABLE_IMAGE_CONTROLLER) deploy/docker/controller
+	docker build -t $(MUTABLE_IMAGE_CONTROLLER) ${DBUILD_ARGS} deploy/docker/controller
 	docker tag $(MUTABLE_IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
-	docker build -t $(MUTABLE_IMAGE_PROVISIONER) deploy/docker/provisioner
+	docker build -t $(MUTABLE_IMAGE_PROVISIONER) ${DBUILD_ARGS} deploy/docker/provisioner
 	docker tag $(MUTABLE_IMAGE_PROVISIONER) $(IMAGE_PROVISIONER)
 
 push: container

--- a/snapshot/deploy/docker/controller/Dockerfile
+++ b/snapshot/deploy/docker/controller/Dockerfile
@@ -26,4 +26,17 @@ COPY snapshot-controller /
 # Root CA certificates
 COPY etc /etc
 COPY usr /usr
+
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="snapshot-controller"
+LABEL org.label-schema.description="OpenEBS Dynamic cStor Snapshot Provisioner"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
 ENTRYPOINT ["/snapshot-controller"]

--- a/snapshot/deploy/docker/provisioner/Dockerfile
+++ b/snapshot/deploy/docker/provisioner/Dockerfile
@@ -27,4 +27,17 @@ COPY snapshot-provisioner /
 # Root CA certificates
 COPY etc /etc
 COPY usr /usr
+
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="snapshot-provisioner"
+LABEL org.label-schema.description="OpenEBS Dynamic cStor Snapshot Provisioner"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
 ENTRYPOINT ["/snapshot-provisioner"]


### PR DESCRIPTION
This commit will help customizing docker images via environment variables:
- The following ENV help specify custom docker build args
  - DBUILD_SITE_URL ( default: https://openebs.io )
  - DBUILD_REPO_URL ( default: https://github.com/openebs/external-storage )
- The following ENV allows Travis to specify custom image org
  - IMAGE_ORG (default: openebs )
- The following ENV will allow specifying an extra tag suffix
  - TAG_SUFFIX ( default: none )

Signed-off-by: kmova <kiran.mova@mayadata.io>