### PR TITLE
refactor(build): trim leading v from image tag

### DIFF
--- a/openebs/buildscripts/push
+++ b/openebs/buildscripts/push
@@ -55,9 +55,18 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 
 function TagAndPushImage() {
   REPO="$1"
-  TAG="$2"
+
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="${2#v}"
   
-  IMAGE_URI="${REPO}:${TAG}";
+  #Add an option to specify a custom TAG_SUFFIX 
+  #via environment variable. Default is no tag.
+  #Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
+
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};


### PR DESCRIPTION
Using the github tag, docker image tags are
created. As we move the github tags to semver
format, the image tags will end up having a
leading `v` in the tag.

To keep the image tag names consistent with
past releases, the leading `v` will be trimmed
from the travis tag and the rest of the string
will be used for image tag.

Examples:
1.10.0 maps to 1.10.0
v1.10.0 maps to 1.10.0
v1.10.0-custom-RC1 maps to 1.10.0-custom-RC1

Signed-off-by: kmova <kiran.mova@mayadata.io>