### PR TITLE
chore(go version): bump go version to 1.14.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 language: go
 
 go:
-  - 1.12.5
+  - 1.14.7
 
 addons:
   apt:


### PR DESCRIPTION
This PR updates the go version to 1.14.7. Since
CVE-2020-16845 has been reported for go versions
earlier to 1.14.7.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>