### PR TITLE
cherry-pick(go version): bump go version to 1.14.7 (#122)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 language: go
 
 go:
-  - 1.12.5
+  - 1.14.7
 
 addons:
   apt:


### PR DESCRIPTION
This PR is cherry-pick of #122.
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
