### PR TITLE
feat(builds): add support for multi arch container images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,171 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: build
+
+on: ['push']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: '.'
+          pattern: '*.sh'
+          exclude: './.git/*,./vendor/*'
+
+  openebs-provisioner:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH#v}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.provisioner
+          make buildx.push.provisioner
+
+  snapshot-controller:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH#v}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.snapshot-controller
+          make buildx.push.snapshot-controller
+
+  snapshot-provisioner:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH#v}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.snapshot-provisioner
+          make buildx.push.snapshot-provisioner

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,107 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ci
+
+on:
+  pull_request:
+    branches:
+      # on pull requests to master and release branches
+      - master
+      - 'v*'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: '.'
+          pattern: '*.sh'
+          exclude: './vendor/*'
+
+  openebs-provisioner:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Build Image
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.provisioner
+
+  snapshot-controller:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Build Image
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.snapshot-controller
+
+  snapshot-provisioner:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Build Image
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.snapshot-provisioner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: release
+
+on:
+  create:
+    tags:
+      - 'v*'
+
+jobs:
+  openebs-provisioner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set Tag
+        run: |
+          TAG="${GITHUB_REF#refs/*/v}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.provisioner
+          make buildx.push.provisioner
+
+  snapshot-controller:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: set tag
+        run: |
+          tag="${github_ref#refs/*/v}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
+
+      - name: set up qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: login to docker hub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: build & push image
+        env:
+          image_org: ${{ secrets.image_org}}
+        run: |
+          make docker.buildx.snapshot-controller
+          make buildx.push.snapshot-controller
+
+  snapshot-provisioner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set Tag
+        run: |
+          TAG="${GITHUB_REF#refs/*/v}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.snapshot-provisioner
+          make buildx.push.snapshot-provisioner

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
+    - RELEASE_TAG=$TRAVIS_TAG
+    - BRANCH=$TRAVIS_BRANCH
 
 services:
   - docker
@@ -29,10 +31,6 @@ jobs:
       arch: amd64
       env:
         - RELEASE_TAG_DOWNSTREAM=1
-    - os: linux
-      arch: arm64
-      env:
-        - RELEASE_TAG_DOWNSTREAM=0
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/Makefile
+++ b/Makefile
@@ -254,3 +254,6 @@ push-openebs-provisioner:
 deploy-openebs-provisioner:
 	cd openebs; \
 	make deploy
+
+include ./openebs/Makefile.buildx.mk
+include ./snapshot/Makefile.buildx.mk

--- a/buildxpush
+++ b/buildxpush
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ -z ${DIMAGE} ];
+then
+  echo "Error: DIMAGE is not specified";
+  exit 1
+fi
+
+function pushBuildx() {
+  BUILD_TAG="latest"
+  TARGET_IMG=${DIMAGE}
+
+# TODO Currently ci builds with commit tag will not be generated,
+# since buildx does not support multiple repo
+  # if not a release build set the tag and ci image
+  if [ -z "${RELEASE_TAG}" ]; then
+    return
+#    BUILD_ID=$(git describe --tags --always)
+#    BUILD_TAG="${BRANCH}-${BUILD_ID}"
+#    TARGET_IMG="${DIMAGE}-ci"
+  fi
+
+  echo "Tagging and pushing ${DIMAGE}:${TAG} as ${TARGET_IMG}:${BUILD_TAG}"
+  docker buildx imagetools create "${DIMAGE}:${TAG}" -t "${TARGET_IMG}:${BUILD_TAG}"
+}
+
+# if the push is for a buildx build
+if [[ ${BUILDX} ]]; then
+  pushBuildx
+  exit 0
+fi

--- a/openebs/Makefile
+++ b/openebs/Makefile
@@ -96,3 +96,4 @@ clean:
 	rm -f openebs-provisioner
 	rm -f buildscripts/docker/openebs-provisioner
 
+include Makefile.buildx.mk

--- a/openebs/Makefile.buildx.mk
+++ b/openebs/Makefile.buildx.mk
@@ -1,0 +1,64 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build openebs provisioner docker images with buildx
+# Experimental docker feature to build cross platform multi-architecture docker images
+# https://docs.docker.com/buildx/working-with-buildx/
+
+# build args
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${RELEASE_TAG} --build-arg BRANCH=${BRANCH}
+
+ifeq (${TAG}, )
+  export TAG=ci
+endif
+
+# default list of platforms for which multiarch image is built
+ifeq (${PLATFORMS}, )
+	export PLATFORMS="linux/amd64,linux/arm64"
+endif
+
+# if IMG_RESULT is unspecified, by default the image will be pushed to registry
+ifeq (${IMG_RESULT}, load)
+	export PUSH_ARG="--load"
+    # if load is specified, image will be built only for the build machine architecture.
+    export PLATFORMS="local"
+else ifeq (${IMG_RESULT}, cache)
+	# if cache is specified, image will only be available in the build cache, it won't be pushed or loaded
+	# therefore no PUSH_ARG will be specified
+else
+	export PUSH_ARG="--push"
+endif
+
+# Name of the multiarch image for provisioner
+DOCKERX_IMAGE_PROVISIONER:=${IMAGE_ORG}/openebs-k8s-provisioner:${TAG}
+
+buildx.provisioner: build
+
+.PHONY: docker.buildx.provisioner
+docker.buildx.provisioner:
+	@echo "--> Build docker image: $(DOCKERX_IMAGE_NAME)"
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	@if ! docker buildx ls | grep -q container-builder; then\
+		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
+	fi
+	@docker buildx build --platform "${PLATFORMS}" \
+		-t "$(DOCKERX_IMAGE_PROVISIONER)" ${DBUILD_ARGS} \
+		-f $(PWD)/openebs/buildscripts/docker/provisioner.Dockerfile \
+		. ${PUSH_ARG}
+	@echo "--> Build docker image: $(DOCKERX_IMAGE_NAME)"
+	@echo
+
+.PHONY: buildx.push.provisioner
+buildx.push.provisioner:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/openebs-provisioner ./buildxpush

--- a/openebs/buildscripts/docker/provisioner.Dockerfile
+++ b/openebs/buildscripts/docker/provisioner.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14.7 as build
+
+ARG RELEASE_TAG
+ARG BRANCH
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
+
+ENV GO111MODULE=off \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
+  DEBIAN_FRONTEND=noninteractive \
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG} \
+  BRANCH=${BRANCH}
+
+WORKDIR /go/src/github.com/kubernetes-incubator/external-storage
+
+COPY . .
+
+RUN make openebs
+
+FROM ubuntu:16.04
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update; exit 0
+
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/openebs/openebs-provisioner /
+
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="openebs-k8s-provisioner"
+LABEL org.label-schema.description="OpenEBS Dynamic cStor and Jiva Provisioner"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
+CMD ["/openebs-provisioner"]

--- a/openebs/buildscripts/push
+++ b/openebs/buildscripts/push
@@ -22,6 +22,31 @@ then
   exit 1
 fi
 
+function pushBuildx() {
+  BUILD_TAG="latest"
+  TARGET_IMG=${DIMAGE}
+
+# TODO Currently ci builds with commit tag will not be generated,
+# since buildx does not support multiple repo
+  # if not a release build set the tag and ci image
+  if [ -z "${RELEASE_TAG}" ]; then
+    return
+#    BUILD_ID=$(git describe --tags --always)
+#    BUILD_TAG="${BRANCH}-${BUILD_ID}"
+#    TARGET_IMG="${DIMAGE}-ci"
+  fi
+
+  echo "Tagging and pushing ${DIMAGE}:${TAG} as ${TARGET_IMG}:${BUILD_TAG}"
+  docker buildx imagetools create "${DIMAGE}:${TAG}" -t "${TARGET_IMG}:${BUILD_TAG}"
+}
+
+# if the push is for a buildx build
+if [[ ${BUILDX} ]]; then
+  pushBuildx
+  exit 0
+fi
+
+
 IMAGEID=$( docker images -q ${DIMAGE}:ci )
 echo $IMAGEID 
 if [ -z ${IMAGEID} ];
@@ -29,6 +54,12 @@ then
   echo "Error: unable to get IMAGEID for ${DIMAGE}:ci";
   exit 1
 fi
+
+if [ -z "${XC_ARCH}" ]; then
+  XC_ARCH="$(go env GOARCH)"
+fi
+
+DIMAGE="${DIMAGE}-${XC_ARCH}"
 
 # Generate a uniqe tag based on the commit and tag
 BUILD_ID=$(git describe --tags --always)
@@ -115,4 +146,3 @@ then
 else
   echo "No docker credentials provided. Skip uploading ${DIMAGE} to quay";
 fi;
-

--- a/snapshot/Makefile
+++ b/snapshot/Makefile
@@ -111,3 +111,5 @@ push: container
 	docker push $(MUTABLE_IMAGE_CONTROLLER)
 	docker push $(IMAGE_PROVISIONER)
 	docker push $(MUTABLE_IMAGE_PROVISIONER)
+
+include Makefile.buildx.mk

--- a/snapshot/Makefile.buildx.mk
+++ b/snapshot/Makefile.buildx.mk
@@ -1,0 +1,79 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build openebs snapshot-provisioner docker images with buildx
+# Experimental docker feature to build cross platform multi-architecture docker images
+# https://docs.docker.com/buildx/working-with-buildx/
+
+# build args
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${RELEASE_TAG}
+
+ifeq (${TAG}, )
+  export TAG=ci
+endif
+
+# default list of platforms for which multiarch image is built
+ifeq (${PLATFORMS}, )
+	export PLATFORMS="linux/amd64,linux/arm64"
+endif
+
+# if IMG_RESULT is unspecified, by default the image will be pushed to registry
+ifeq (${IMG_RESULT}, load)
+	export PUSH_ARG="--load"
+    # if load is specified, image will be built only for the build machine architecture.
+    export PLATFORMS="local"
+else ifeq (${IMG_RESULT}, cache)
+	# if cache is specified, image will only be available in the build cache, it won't be pushed or loaded
+	# therefore no PUSH_ARG will be specified
+else
+	export PUSH_ARG="--push"
+endif
+
+# Name of the multiarch image for snapshot-provisioner and controller
+DOCKERX_IMAGE_SNAPSHOTTER:=${IMAGE_ORG}/snapshot-controller:${TAG}
+DOCKERX_IMAGE_PROVISIONER:=${IMAGE_ORG}/snapshot-provisioner:${TAG}
+
+.PHONY: docker.buildx
+docker.buildx:
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	@if ! docker buildx ls | grep -q container-builder; then\
+		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
+	fi
+	@docker buildx build --platform "${PLATFORMS}" \
+		-t "$(DOCKERX_IMAGE_NAME)" ${BUILD_ARGS} \
+		-f $(PWD)/snapshot/deploy/docker/$(COMPONENT)/$(COMPONENT).Dockerfile \
+		. ${PUSH_ARG}
+	@echo "--> Build docker image: $(DOCKERX_IMAGE_NAME)"
+	@echo
+
+.PHONY: docker.buildx.snapshot-controller
+docker.buildx.snapshot-controller: DOCKERX_IMAGE_NAME=$(DOCKERX_IMAGE_SNAPSHOTTER)
+docker.buildx.snapshot-controller: COMPONENT=controller
+docker.buildx.snapshot-controller: BUILD_ARGS=$(DBUILD_ARGS)
+docker.buildx.snapshot-controller: docker.buildx
+
+.PHONY: docker.buildx.snapshot-provisioner
+docker.buildx.snapshot-provisioner: DOCKERX_IMAGE_NAME=$(DOCKERX_IMAGE_PROVISIONER)
+docker.buildx.snapshot-provisioner: COMPONENT=provisioner
+docker.buildx.snapshot-provisioner: BUILD_ARGS=$(DBUILD_ARGS)
+docker.buildx.snapshot-provisioner: docker.buildx
+
+
+.PHONY: buildx.push.snapshot-controller
+buildx.push.snapshot-controller:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/snapshot-controller ./buildxpush
+
+.PHONY: buildx.push.snapshot-provisioner
+buildx.push.snapshot-provisioner:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/snapshot-provisioner ./buildxpush

--- a/snapshot/deploy/docker/controller/controller.Dockerfile
+++ b/snapshot/deploy/docker/controller/controller.Dockerfile
@@ -1,0 +1,65 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14.7 as build
+
+ARG RELEASE_TAG
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
+
+ENV GO111MODULE=off \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
+  DEBIAN_FRONTEND=noninteractive \
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG}
+
+WORKDIR /go/src/github.com/kubernetes-incubator/external-storage
+
+RUN apt-get update && apt-get install -y make git
+
+COPY . .
+
+RUN cd snapshot && make controller
+
+FROM alpine:3.11.5
+
+RUN apk add --no-cache \
+    bash \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat \
+    ca-certificates
+
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="snapshot-controller"
+LABEL org.label-schema.description="OpenEBS Dynamic cStor Snapshot Provisioner"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
+# copy the latest binary
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/snapshot/_output/bin/snapshot-controller /
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/snapshot/deploy/ca-certificates/etc /etc
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/snapshot/deploy/ca-certificates/usr /etc
+
+ENTRYPOINT ["/snapshot-controller"]

--- a/snapshot/deploy/docker/provisioner/provisioner.Dockerfile
+++ b/snapshot/deploy/docker/provisioner/provisioner.Dockerfile
@@ -1,0 +1,64 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14.7 as build
+
+ARG RELEASE_TAG
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
+
+ENV GO111MODULE=off \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
+  DEBIAN_FRONTEND=noninteractive \
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG}
+
+WORKDIR /go/src/github.com/kubernetes-incubator/external-storage
+
+RUN apt-get update && apt-get install -y make git
+
+COPY . .
+
+RUN cd snapshot && make provisioner
+
+FROM alpine:3.11.5
+
+RUN apk add --no-cache \
+    bash \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat \
+    ca-certificates
+
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="snapshot-provisioner"
+LABEL org.label-schema.description="OpenEBS Dynamic cStor Snapshot Provisioner"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
+# copy the latest binary
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/snapshot/_output/bin/snapshot-provisioner /
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/snapshot/deploy/ca-certificates/etc /etc
+COPY --from=build /go/src/github.com/kubernetes-incubator/external-storage/snapshot/deploy/ca-certificates/usr /etc
+
+ENTRYPOINT ["/snapshot-provisioner"]


### PR DESCRIPTION
**Why we need this change**
- Add the support for multi arch for openebs-provisioner, snapshot-controller, snapshot-provisioner images using github action
- Suffix the $ARCH to the travis container build images i.e. `openebs-provisioner-amd64` 
- Update the deprecated warning for set-env in github action 

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>