### PR TITLE
feat(jiva): env to enable/disable replica patch

### DIFF
--- a/openebs/pkg/volume/v1alpha1/volume.go
+++ b/openebs/pkg/volume/v1alpha1/volume.go
@@ -150,11 +150,16 @@ func (v CASVolume) ReadVolume(vname, namespace, storageclass string, obj interfa
 		return err
 	}
 
+	patchJivaReplicaWithNodeAffinity := os.Getenv("OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY")
+	if patchJivaReplicaWithNodeAffinity == "" {
+		patchJivaReplicaWithNodeAffinity = "enabled"
+	}
+
 	req.Header.Set("namespace", namespace)
 	// passing storageclass info as a request header which will extracted by the
 	// Maya-apiserver to get the CAS template name
 	req.Header.Set(string(v1alpha1.StorageClassHeaderKey), storageclass)
-	req.Header.Set(string(v1alpha1.IsPatchJivaReplicaNodeAffinityHeader), "enabled")
+	req.Header.Set(string(v1alpha1.IsPatchJivaReplicaNodeAffinityHeader), patchJivaReplicaWithNodeAffinity)
 
 	c := &http.Client{
 		Timeout: timeout,


### PR DESCRIPTION
Ref: https://github.com/openebs/openebs/issues/3226

In some cases, users would like to disable setting
the patch on jiva replica. These are clusters which
guarantee that only one node is out of the cluster
at any given time and when it comes back, it can
come back with an new hostname, making the replica
deployment unschedulable.

The setting can be controlled via ENV variable.
`OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY`

Default: enabled. 

Note: 
- This env applies to all the jiva volumes in the cluster. 
- This applies to the case where replica affinity is set in the read operation followed by a create. In some cases, the create may not be able to set the affinity, as k8s would have not initialized the replica's yet. 


Signed-off-by: kmova <kiran.mova@mayadata.io>