### PR TITLE
chore(build): disable migrated provisioner build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,53 +31,6 @@ jobs:
           pattern: '*.sh'
           exclude: './.git/*,./vendor/*'
 
-  openebs-provisioner:
-    runs-on: ubuntu-latest
-    needs: ['lint']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set tag
-        run: |
-          BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH#v}-ci
-          if [ ${BRANCH} = "release" ]; then
-            CI_TAG="ci"
-          fi
-
-          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Print Tag info
-        run: |
-          echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.provisioner
-          make buildx.push.provisioner
-
   snapshot-controller:
     runs-on: ubuntu-latest
     needs: ['lint']

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,29 +37,6 @@ jobs:
           pattern: '*.sh'
           exclude: './vendor/*'
 
-  openebs-provisioner:
-    runs-on: ubuntu-latest
-    needs: ['lint']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.provisioner
-
   snapshot-controller:
     runs-on: ubuntu-latest
     needs: ['lint']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,46 +19,6 @@ on:
       - 'v*'
 
 jobs:
-  openebs-provisioner:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Set Tag
-        run: |
-          TAG="${GITHUB_REF#refs/*/v}"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
-          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
-
-      - name: Print Tag info
-        run: |
-          echo "RELEASE TAG: ${RELEASE_TAG}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.provisioner
-          make buildx.push.provisioner
-
   snapshot-controller:
     runs-on: ubuntu-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ script:
 
       REL_BRANCH=$(echo $(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x$REL_SUFFIX);
 
-      ./openebs/buildscripts/git-release "$REPO_ORG/maya" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      ./openebs/buildscripts/git-release "$REPO_ORG/openebs-k8s-provisioner" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
     fi
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,54 +1,14 @@
-# External Storage
-[![Build Status](https://travis-ci.org/kubernetes-incubator/external-storage.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/external-storage)
-[![GoDoc](https://godoc.org/github.com/kubernetes-incubator/external-storage?status.svg)](https://godoc.org/github.com/kubernetes-incubator/external-storage)
-[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-incubator/external-storage)](https://goreportcard.com/report/github.com/kubernetes-incubator/external-storage)
+This repository is home for Kubenretes external-storage based Volume provisioners. 
 
-## External Provisioners
-This repository houses community-maintained external provisioners plus a helper library for building them. Each provisioner is contained in its own directory so for information on how to use one, enter its directory and read its documentation. The library is contained in the `lib` directory.
+The early engines Jiva and cStor were using the provisioners built from this repository. As Kubernetes community has retired this upstream repository, OpenEBS community are in the process of migrating the code from this repo to component specific repositories. 
 
-### What is an 'external provisioner'?
-An external provisioner is a dynamic PV provisioner whose code lives out-of-tree/external to Kubernetes. Unlike [in-tree dynamic provisioners](https://kubernetes.io/docs/concepts/storage/storage-classes/#provisioner) that run as part of the Kubernetes controller manager, external ones can be deployed & updated independently.
+If you are looking for the OpenEBS K8s Provisioner, it has already been migrated to https://github.com/openebs/openebs-k8s-provisioner.
 
-External provisioners work just like in-tree dynamic PV provisioners. A `StorageClass` object can specify an external provisioner instance to be its `provisioner` like it can in-tree provisioners. The instance will then watch for `PersistentVolumeClaims` that ask for the `StorageClass` and automatically create `PersistentVolumes` for them. For more information on how dynamic provisioning works, see [the docs](http://kubernetes.io/docs/user-guide/persistent-volumes/) or [this blog post](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html).
+This repository is only used for building the snapshot-provionsers used by cStor pools provisioned with SPC. 
 
-### How to use the library
-```go
-import (
-  "github.com/kubernetes-incubator/external-storage/lib/controller"
-)
-```
-You need to implement the `Provisioner` interface then pass your implementation to a `ProvisionController` and run the controller. The controller takes care of deciding when to call your implementation's `Provision` or `Delete`. The interface and controller are defined in the above package.
+_Note: The snapshot provisioners are already deprecated by Kubernetes and will soon be deprecated by the OpenEBS community in favor of the cStor CSI Driver available at https://github.com/openebs/cstor-operators_
 
-You will want to import a specific version of the library to ensure compatibility with certain versions of Kubernetes and to avoid breaking changes. This repo will be tagged according to the library's version (individual provisioners will need to version themselves independently, e.g. by in their documentation pointing to Docker Hub and using Docker tags), so to keep track of releases, go to this repo's [releases page](https://github.com/kubernetes-incubator/external-storage/releases).
+For further questions or if you need any help, please reach out to the maintainers via [Kubernetes Slack](https://kubernetes.slack.com).
+  * Head to our user discussions at [#openebs](https://kubernetes.slack.com/messages/openebs/)
+  * Head to our contributor discussions at [#openebs-dev](https://kubernetes.slack.com/messages/openebs-dev/)
 
-Note that because your provisioner needs to depend also on [client-go](https://github.com/kubernetes/client-go) and the library itself depends on a specific version of client-go, to avoid a dependency conflict you must ensure you use the exact same version of client-go as the library. You can check what version of client-go the library depends on by looking at its [glide.yaml](lib/glide.yaml).
-
-[For all documentation, including a full guide on how to write an external provisioner using the library that demonstrates the above, see here](./docs).
-
-### `client-go` integration strategy
-This library is integrated with `client-go` `master` branch. As soon as the `client-go` `master` branch contains a new version of `client-go` vendor dependencies, dependencies of this library shall be updated to the tip of the `client-go` `master` branch.
-
-## Roadmap
-
-February
-* Finalize repo structure, release process, etc.
-
-## Community, discussion, contribution, and support
-
-Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
-
-You can reach the maintainers of this project at:
-
-- Slack: #sig-storage
-
-## Kubernetes Incubator
-
-This is a [Kubernetes Incubator project](https://github.com/kubernetes/community/blob/master/incubator.md). The project was established 2016-11-15 (as nfs-provisioner). The incubator team for the project is:
-
-- Sponsor: Clayton (@smarterclayton)
-- Champion: Jan (@jsafrane) & Brad (@childsb)
-- SIG: sig-storage
-
-### Code of conduct
-
-Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The early engines Jiva and cStor were using the provisioners built from this rep
 
 If you are looking for the OpenEBS K8s Provisioner, it has already been migrated to https://github.com/openebs/openebs-k8s-provisioner.
 
-This repository is only used for building the snapshot-provionsers used by cStor pools provisioned with SPC. 
+This repository is only used for building the snapshot provionsers used by cStor pools provisioned with SPC. 
 
 _Note: The snapshot provisioners are already deprecated by Kubernetes and will soon be deprecated by the OpenEBS community in favor of the cStor CSI Driver available at https://github.com/openebs/cstor-operators_
 

--- a/openebs-build.sh
+++ b/openebs-build.sh
@@ -20,10 +20,10 @@ DST_REPO="$GOPATH/src/github.com/kubernetes-incubator"
 mkdir -p $DST_REPO
 cp -R $SRC_REPO/../external-storage $DST_REPO
 
-echo "Building openebs-provisioner"
-cd $DST_REPO/external-storage/openebs
-make container
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+#echo "Building openebs-provisioner"
+#cd $DST_REPO/external-storage/openebs
+#make container
+#rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 echo "Building snapshot-controller and snapshot-provisioner"
 cd $DST_REPO/external-storage/snapshot

--- a/openebs-deploy.sh
+++ b/openebs-deploy.sh
@@ -22,8 +22,8 @@ if [ -z "${IMAGE_ORG}" ]; then
 fi
 
 if [ "${ARCH}" = "x86_64" ]; then
-	export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner"
-	./openebs/buildscripts/push
+	#export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner"
+	#./openebs/buildscripts/push
 
 	export DIMAGE="${IMAGE_ORG}/snapshot-controller"
 	./openebs/buildscripts/push
@@ -31,8 +31,8 @@ if [ "${ARCH}" = "x86_64" ]; then
 	export DIMAGE="${IMAGE_ORG}/snapshot-provisioner"
 	./openebs/buildscripts/push
 elif [ "${ARCH}" = "aarch64" ]; then
-	export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner-arm64"
-	./openebs/buildscripts/push
+	#export DIMAGE="${IMAGE_ORG}/openebs-k8s-provisioner-arm64"
+	#./openebs/buildscripts/push
 
 	export DIMAGE="${IMAGE_ORG}/snapshot-controller-arm64"
 	./openebs/buildscripts/push

--- a/openebs/ci/build-images.sh
+++ b/openebs/ci/build-images.sh
@@ -8,13 +8,13 @@ echo "*****************************Retagging images and setting up env**********
 # - during the release time, the image tags can be versioned like 0.7.0-RC..
 # - from a branch, the image tags can be the branch names like v0.7.x-ci
 if [ ${CI_TAG} != "ci" ]; then
-  sudo docker tag openebs/openebs-k8s-provisioner:ci openebs/openebs-k8s-provisioner:${CI_TAG}
+  #sudo docker tag openebs/openebs-k8s-provisioner:ci openebs/openebs-k8s-provisioner:${CI_TAG}
   sudo docker tag openebs/snapshot-controller:ci openebs/snapshot-controller:${CI_TAG}
   sudo docker tag openebs/snapshot-provisioner:ci openebs/snapshot-provisioner:${CI_TAG}
 fi
 
 #Tag the images with quay.io, since the operator can either have quay or docker images
-sudo docker tag openebs/openebs-k8s-provisioner:ci quay.io/openebs/openebs-k8s-provisioner:${CI_TAG}
+#sudo docker tag openebs/openebs-k8s-provisioner:ci quay.io/openebs/openebs-k8s-provisioner:${CI_TAG}
 sudo docker tag openebs/snapshot-controller:ci quay.io/openebs/snapshot-controller:${CI_TAG}
 sudo docker tag openebs/snapshot-provisioner:ci quay.io/openebs/snapshot-provisioner:${CI_TAG}
 


### PR DESCRIPTION
The openebs-provisioner code has been migrated to
https://github.com/openebs/openebs-k8s-provisioner

This PR disables the build scripts for openebs-provisioner
and also update the README with new repo information.

Signed-off-by: kmova <kiran.mova@mayadata.io>